### PR TITLE
Task 49 : API Endpoint Jadwal Pengajian

### DIFF
--- a/app/Http/Controllers/Api/PublicScheduleController.php
+++ b/app/Http/Controllers/Api/PublicScheduleController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Lecturing;
+use Carbon\Carbon;
+use Illuminate\Http\Request;
+
+class PublicScheduleController extends Controller
+{
+    public function index(Request $request)
+    {
+        $lecturingQuery = Lecturing::query();
+        $startDate = $request->startDate ? $request->startDate : Carbon::now()->startOfMonth();
+        $endDate = $request->endDate ? $request->endDate : Carbon::now()->endOfMonth();
+        $lecturingQuery->whereBetween('date', [$startDate, $endDate]);
+        $lecturingQuery->orderBy('date')->orderBy('start_time');
+        $lecturings = $lecturingQuery->get()->groupBy('audience_code');
+        
+        return response()->json($lecturings);
+    }
+}

--- a/app/Http/Controllers/Api/PublicScheduleController.php
+++ b/app/Http/Controllers/Api/PublicScheduleController.php
@@ -12,8 +12,8 @@ class PublicScheduleController extends Controller
     public function index(Request $request)
     {
         $lecturingQuery = Lecturing::query();
-        $startDate = $request->startDate ? $request->startDate : Carbon::now()->startOfMonth();
-        $endDate = $request->endDate ? $request->endDate : Carbon::now()->endOfMonth();
+        $startDate = $request->get('start_date', Carbon::now()->startOfMonth()->format('Y-m-d'));
+        $endDate = $request->get('end_date', Carbon::now()->endOfMonth()->format('Y-m-d'));
         $lecturingQuery->whereBetween('date', [$startDate, $endDate]);
         $lecturingQuery->orderBy('date')->orderBy('start_time');
         $lecturings = $lecturingQuery->get()->groupBy('audience_code');

--- a/routes/api.php
+++ b/routes/api.php
@@ -11,6 +11,9 @@
 |
 */
 
+// Public Routes
+Route::get('schedules', 'Api\PublicScheduleController@index')->name('api.schedules.index');
+
 // Authentication Routes...
 Route::post('login', 'Api\Auth\LoginController@login')->name('api.login');
 

--- a/tests/Feature/Api/PublicScheduleTest.php
+++ b/tests/Feature/Api/PublicScheduleTest.php
@@ -17,19 +17,25 @@ class PublicScheduleTest extends TestCase
         $lecturing = factory(Lecturing::class)->create([
             'audience_code' => Lecturing::AUDIENCE_FRIDAY,
             'date' => Carbon::tomorrow()->format('Y-m-d'),
+            'lecturer_name' => 'Ustadz Haikal',
+            'imam_name' => 'Ustadz Febri',
+            'muadzin_name' => 'Ahmad',
         ]);
 
         $unlistedLecturing = factory(Lecturing::class)->create([
             'audience_code' => Lecturing::AUDIENCE_PUBLIC,
             'date' => Carbon::yesterday()->format('Y-m-d'),
+            'lecturer_name' => 'Ustadz Fauzan',
+            'imam_name' => 'Abdussamad',
+            'muadzin_name' => 'Tono',
         ]);
 
         $startDate = Carbon::now()->format('Y-m-d');
         $endDate = Carbon::now()->addDays(7)->format('Y-m-d');
 
         $this->getJson(route('api.schedules.index', [
-            'startDate' => $startDate,
-            'endDate' => $endDate,
+            'start_date' => $startDate,
+            'end_date' => $endDate,
         ]));
 
         $this->seeJson([

--- a/tests/Feature/Api/PublicScheduleTest.php
+++ b/tests/Feature/Api/PublicScheduleTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\Lecturing;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class PublicScheduleTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function can_get_schedules_within_specified_date_range() {
+        $lecturing = factory(Lecturing::class)->create([
+            'audience_code' => Lecturing::AUDIENCE_FRIDAY,
+            'date' => Carbon::tomorrow()->format('Y-m-d')
+        ]);
+
+        $startDate = Carbon::now()->format('Y-m-d');
+        $endDate = Carbon::now()->addDays(7)->format('Y-m-d');
+
+        $this->getJson(route('api.schedules.index', [
+            'startDate' => $startDate,
+            'endDate' => $endDate
+        ]));
+
+        $this->seeJson([
+            'lecturer_name' => $lecturing->lecturer_name,
+            'imam_name' => $lecturing->imam_name,
+            'muadzin_name' => $lecturing->muadzin_name
+        ]);
+    }
+
+    /** @test */
+    public function can_get_schedules_without_specified_date_range() {
+        $lecturing = factory(Lecturing::class)->create([
+            'audience_code' => Lecturing::AUDIENCE_FRIDAY,
+            'date' => Carbon::now()->startOfMonth()->addDays(rand(0, 29))
+        ]);
+
+        $this->getJson(route('api.schedules.index'));
+
+        $this->seeJson([
+            'lecturer_name' => $lecturing->lecturer_name,
+            'imam_name' => $lecturing->imam_name,
+            'muadzin_name' => $lecturing->muadzin_name
+        ]);
+    }
+}

--- a/tests/Feature/Api/PublicScheduleTest.php
+++ b/tests/Feature/Api/PublicScheduleTest.php
@@ -5,7 +5,6 @@ namespace Tests\Feature\Api;
 use App\Models\Lecturing;
 use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
 
 class PublicScheduleTest extends TestCase
@@ -13,10 +12,16 @@ class PublicScheduleTest extends TestCase
     use RefreshDatabase;
 
     /** @test */
-    public function can_get_schedules_within_specified_date_range() {
+    public function can_get_schedules_within_specified_date_range() 
+    {
         $lecturing = factory(Lecturing::class)->create([
             'audience_code' => Lecturing::AUDIENCE_FRIDAY,
-            'date' => Carbon::tomorrow()->format('Y-m-d')
+            'date' => Carbon::tomorrow()->format('Y-m-d'),
+        ]);
+
+        $unlistedLecturing = factory(Lecturing::class)->create([
+            'audience_code' => Lecturing::AUDIENCE_PUBLIC,
+            'date' => Carbon::yesterday()->format('Y-m-d'),
         ]);
 
         $startDate = Carbon::now()->format('Y-m-d');
@@ -24,21 +29,28 @@ class PublicScheduleTest extends TestCase
 
         $this->getJson(route('api.schedules.index', [
             'startDate' => $startDate,
-            'endDate' => $endDate
+            'endDate' => $endDate,
         ]));
 
         $this->seeJson([
             'lecturer_name' => $lecturing->lecturer_name,
             'imam_name' => $lecturing->imam_name,
-            'muadzin_name' => $lecturing->muadzin_name
+            'muadzin_name' => $lecturing->muadzin_name,
+        ]);
+
+        $this->dontSeeJson([
+            'lecturer_name' => $unlistedLecturing->lecturer_name,
+            'imam_name' => $unlistedLecturing->imam_name,
+            'muadzin_name' => $unlistedLecturing->muadzin_name,
         ]);
     }
 
     /** @test */
-    public function can_get_schedules_without_specified_date_range() {
+    public function can_get_schedules_without_specified_date_range() 
+    {
         $lecturing = factory(Lecturing::class)->create([
             'audience_code' => Lecturing::AUDIENCE_FRIDAY,
-            'date' => Carbon::now()->startOfMonth()->addDays(rand(0, 29))
+            'date' => Carbon::now()->startOfMonth()->addDays(rand(0, 29)),
         ]);
 
         $this->getJson(route('api.schedules.index'));
@@ -46,7 +58,7 @@ class PublicScheduleTest extends TestCase
         $this->seeJson([
             'lecturer_name' => $lecturing->lecturer_name,
             'imam_name' => $lecturing->imam_name,
-            'muadzin_name' => $lecturing->muadzin_name
+            'muadzin_name' => $lecturing->muadzin_name,
         ]);
     }
 }


### PR DESCRIPTION
## Description

Pada PR ini, kita ingin membuat satu endpoint yang menampilkan jadwal pengajian pada masjid tersebut berdasarkan rentang tanggal yang dipilih

## Task Link

- #49

## Endpoint
```
GET /api/schedules
```

## Response
```
{
    "friday": [
        {
            "id": "",
            "audience_code": "",
            "date": "",
            "start_time": "",
            "end_time": "",
            "time_text": "",
            "lecturer_name": "",
            "muadzin_name": "",
            "imam_name": "",
            "title": "",
            "book_title": "",
            "book_writer": "",
            "book_link": "",
            "video_link": "",
            "audio_link": "",
            "description": "",
            "is_off": "",
            "created_at": "",
            "updated_at": ""
        }
    ],
    "public": [],
    "muslimah": [],
    "tarawih": []
}
```

## Checklist
- [x] Membuat endpoint publik jadwal
- [x] Memastikan response sesuai target response
- [x] Membuat automated testing

## Review

- [x] Update code style dengan PSR12 dan StyleCI (link terlampir di komentar)
- [x] Tambahkan assert bahwa jadwal diluar rantang tanggal tidak kelihatan
- [x] Update proses payload `$request` sesuai konvensi.

## Screenshoot
<img width="1440" alt="Screen Shot 2024-03-15 at 14 04 26" src="https://github.com/buku-masjid/buku-masjid/assets/87260188/dc9af5c7-4834-4151-b5e7-154a88751784">
