### PR TITLE
Melihat Laporan 1 Tahun

### DIFF
--- a/app/Http/Controllers/Reports/FinanceController.php
+++ b/app/Http/Controllers/Reports/FinanceController.php
@@ -67,8 +67,16 @@ class FinanceController extends Controller
             }
         }
 
-        $year = $request->get('year', date('Y'));
-        $month = $request->get('month', date('m'));
+        if ($request->has('year') && $request->has('month')) {
+            $year = $request->get('year');
+            $month = $request->get('month');
+            if ($month == '00') {
+                return Carbon::parse($year.'-01-01');
+            }
+
+            return Carbon::parse($year.'-'.$month.'-01');
+        }
+
         $yearMonth = $this->getYearMonth();
 
         return Carbon::parse($yearMonth.'-01');
@@ -90,8 +98,19 @@ class FinanceController extends Controller
             return Carbon::parse($request->get('end_date'));
         }
 
-        $year = $request->get('year', date('Y'));
-        $month = $request->get('month', date('m'));
+        if ($request->has('year') && $request->has('month')) {
+            $year = $request->get('year');
+            $month = $request->get('month');
+            if ($month == '00') {
+                if ($year == Carbon::now()->format('Y')) {
+                    return Carbon::now();
+                }
+                return Carbon::parse($year.'-12-31');
+            }
+
+            return Carbon::parse(Carbon::parse($year.'-'.$month.'-10')->format('Y-m-t'));
+        }
+
         $yearMonth = $this->getYearMonth();
 
         return Carbon::parse($yearMonth.'-01')->endOfMonth();

--- a/app/Http/Controllers/Reports/FinanceController.php
+++ b/app/Http/Controllers/Reports/FinanceController.php
@@ -105,6 +105,7 @@ class FinanceController extends Controller
                 if ($year == Carbon::now()->format('Y')) {
                     return Carbon::now();
                 }
+
                 return Carbon::parse($year.'-12-31');
             }
 

--- a/resources/lang/en/app.php
+++ b/resources/lang/en/app.php
@@ -15,6 +15,7 @@ return [
     'type' => 'Type',
     'total' => 'Total',
     'count' => 'Count',
+    'all' => 'All',
     'remark' => 'Remark',
     'level' => 'Level',
     'not_available' => 'Not Available',

--- a/resources/lang/id/app.php
+++ b/resources/lang/id/app.php
@@ -15,6 +15,7 @@ return [
     'type' => 'Jenis',
     'total' => 'Total',
     'count' => 'Jumlah',
+    'all' => 'Semua',
     'remark' => 'Keterangan',
     'level' => 'Level',
     'not_available' => 'Tidak Tersedia',

--- a/resources/views/public_reports/finance/in_months/categorized.blade.php
+++ b/resources/views/public_reports/finance/in_months/categorized.blade.php
@@ -8,7 +8,7 @@
     <div class="page-options d-flex">
         {{ Form::open(['method' => 'get', 'class' => 'form-inline']) }}
         {{ Form::label('month', __('report.view_monthly_label'), ['class' => 'control-label mr-1']) }}
-        {{ Form::select('month', ['00' => '-- All --'] + get_months(), request('month', $startDate->format('m')), ['class' => 'form-control mr-1']) }}
+        {{ Form::select('month', ['00' => '-- '.__('app.all').' --'] + get_months(), request('month', $startDate->format('m')), ['class' => 'form-control mr-1']) }}
         {{ Form::select('year', get_years(), $startDate->format('Y'), ['class' => 'form-control mr-1']) }}
         <div class="form-group mt-4 mt-sm-0">
             {{ Form::hidden('active_book_id', request('active_book_id')) }}

--- a/resources/views/public_reports/finance/in_months/categorized.blade.php
+++ b/resources/views/public_reports/finance/in_months/categorized.blade.php
@@ -8,7 +8,7 @@
     <div class="page-options d-flex">
         {{ Form::open(['method' => 'get', 'class' => 'form-inline']) }}
         {{ Form::label('month', __('report.view_monthly_label'), ['class' => 'control-label mr-1']) }}
-        {{ Form::select('month', get_months(), $startDate->format('m'), ['class' => 'form-control mr-1']) }}
+        {{ Form::select('month', ['00' => '-- All --'] + get_months(), request('month', $startDate->format('m')), ['class' => 'form-control mr-1']) }}
         {{ Form::select('year', get_years(), $startDate->format('Y'), ['class' => 'form-control mr-1']) }}
         <div class="form-group mt-4 mt-sm-0">
             {{ Form::hidden('active_book_id', request('active_book_id')) }}
@@ -16,10 +16,12 @@
             {{ Form::submit(__('report.view_report'), ['class' => 'btn btn-info mr-1']) }}
             {{ link_to_route('public_reports.finance.categorized', __('report.this_month'), Request::except(['year', 'month']), ['class' => 'btn btn-secondary mr-1']) }}
         </div>
-        <div class="form-group">
-            @livewire('prev-month-button', ['routeName' => 'public_reports.finance.categorized', 'buttonClass' => 'btn btn-secondary mr-1'])
-            @livewire('next-month-button', ['routeName' => 'public_reports.finance.categorized', 'buttonClass' => 'btn btn-secondary'])
-        </div>
+        @if (request('month') != '00')
+            <div class="form-group">
+                @livewire('prev-month-button', ['routeName' => 'public_reports.finance.categorized', 'buttonClass' => 'btn btn-secondary mr-1'])
+                @livewire('next-month-button', ['routeName' => 'public_reports.finance.categorized', 'buttonClass' => 'btn btn-secondary'])
+            </div>
+        @endif
         {{ Form::close() }}
     </div>
 </div>

--- a/resources/views/public_reports/finance/in_months/detailed.blade.php
+++ b/resources/views/public_reports/finance/in_months/detailed.blade.php
@@ -8,7 +8,7 @@
     <div class="page-options d-flex">
         {{ Form::open(['method' => 'get', 'class' => 'form-inline']) }}
         {{ Form::label('month', __('report.view_monthly_label'), ['class' => 'control-label mr-1']) }}
-        {{ Form::select('month', ['00' => '-- All --'] + get_months(), request('month', $startDate->format('m')), ['class' => 'form-control mr-1']) }}
+        {{ Form::select('month', ['00' => '-- '.__('app.all').' --'] + get_months(), request('month', $startDate->format('m')), ['class' => 'form-control mr-1']) }}
         {{ Form::select('year', get_years(), $startDate->format('Y'), ['class' => 'form-control mr-1']) }}
         <div class="form-group mt-4 mt-sm-0">
             {{ Form::hidden('active_book_id', request('active_book_id')) }}

--- a/resources/views/public_reports/finance/in_months/detailed.blade.php
+++ b/resources/views/public_reports/finance/in_months/detailed.blade.php
@@ -8,7 +8,7 @@
     <div class="page-options d-flex">
         {{ Form::open(['method' => 'get', 'class' => 'form-inline']) }}
         {{ Form::label('month', __('report.view_monthly_label'), ['class' => 'control-label mr-1']) }}
-        {{ Form::select('month', get_months(), $startDate->format('m'), ['class' => 'form-control mr-1']) }}
+        {{ Form::select('month', ['00' => '-- All --'] + get_months(), request('month', $startDate->format('m')), ['class' => 'form-control mr-1']) }}
         {{ Form::select('year', get_years(), $startDate->format('Y'), ['class' => 'form-control mr-1']) }}
         <div class="form-group mt-4 mt-sm-0">
             {{ Form::hidden('active_book_id', request('active_book_id')) }}
@@ -16,10 +16,12 @@
             {{ Form::submit(__('report.view_report'), ['class' => 'btn btn-info mr-1']) }}
             {{ link_to_route('public_reports.finance.detailed', __('report.this_month'), Request::except(['year', 'month']), ['class' => 'btn btn-secondary mr-1']) }}
         </div>
-        <div class="form-group">
-            @livewire('prev-month-button', ['routeName' => 'public_reports.finance.detailed', 'buttonClass' => 'btn btn-secondary mr-1'])
-            @livewire('next-month-button', ['routeName' => 'public_reports.finance.detailed', 'buttonClass' => 'btn btn-secondary'])
-        </div>
+        @if (request('month') != '00')
+            <div class="form-group">
+                @livewire('prev-month-button', ['routeName' => 'public_reports.finance.detailed', 'buttonClass' => 'btn btn-secondary mr-1'])
+                @livewire('next-month-button', ['routeName' => 'public_reports.finance.detailed', 'buttonClass' => 'btn btn-secondary'])
+            </div>
+        @endif
         {{ Form::close() }}
     </div>
 </div>

--- a/resources/views/public_reports/finance/in_months/summary.blade.php
+++ b/resources/views/public_reports/finance/in_months/summary.blade.php
@@ -8,7 +8,7 @@
     <div class="page-options d-flex">
         {{ Form::open(['method' => 'get', 'class' => 'form-inline']) }}
         {{ Form::label('month', __('report.view_monthly_label'), ['class' => 'control-label mr-1']) }}
-        {{ Form::select('month', ['00' => '-- All --'] + get_months(), request('month', $startDate->format('m')), ['class' => 'form-control mr-1']) }}
+        {{ Form::select('month', ['00' => '-- '.__('app.all').' --'] + get_months(), request('month', $startDate->format('m')), ['class' => 'form-control mr-1']) }}
         {{ Form::select('year', get_years(), $startDate->format('Y'), ['class' => 'form-control mr-1']) }}
         <div class="form-group mt-4 mt-sm-0">
             {{ Form::hidden('active_book_id', request('active_book_id')) }}

--- a/resources/views/public_reports/finance/in_months/summary.blade.php
+++ b/resources/views/public_reports/finance/in_months/summary.blade.php
@@ -8,7 +8,7 @@
     <div class="page-options d-flex">
         {{ Form::open(['method' => 'get', 'class' => 'form-inline']) }}
         {{ Form::label('month', __('report.view_monthly_label'), ['class' => 'control-label mr-1']) }}
-        {{ Form::select('month', get_months(), $startDate->format('m'), ['class' => 'form-control mr-1']) }}
+        {{ Form::select('month', ['00' => '-- All --'] + get_months(), request('month', $startDate->format('m')), ['class' => 'form-control mr-1']) }}
         {{ Form::select('year', get_years(), $startDate->format('Y'), ['class' => 'form-control mr-1']) }}
         <div class="form-group mt-4 mt-sm-0">
             {{ Form::hidden('active_book_id', request('active_book_id')) }}
@@ -16,10 +16,12 @@
             {{ Form::submit(__('report.view_report'), ['class' => 'btn btn-info mr-1']) }}
             {{ link_to_route('public_reports.finance.summary', __('report.this_month'), Request::except(['year', 'month']), ['class' => 'btn btn-secondary mr-1']) }}
         </div>
-        <div class="form-group">
-            @livewire('prev-month-button', ['routeName' => 'public_reports.finance.summary', 'buttonClass' => 'btn btn-secondary mr-1'])
-            @livewire('next-month-button', ['routeName' => 'public_reports.finance.summary', 'buttonClass' => 'btn btn-secondary'])
-        </div>
+        @if (request('month') != '00')
+            <div class="form-group">
+                @livewire('prev-month-button', ['routeName' => 'public_reports.finance.summary', 'buttonClass' => 'btn btn-secondary mr-1'])
+                @livewire('next-month-button', ['routeName' => 'public_reports.finance.summary', 'buttonClass' => 'btn btn-secondary'])
+            </div>
+        @endif
         {{ Form::close() }}
     </div>
 </div>

--- a/resources/views/reports/finance/in_months/categorized.blade.php
+++ b/resources/views/reports/finance/in_months/categorized.blade.php
@@ -33,17 +33,19 @@
     <div class="page-options d-flex">
         {{ Form::open(['method' => 'get', 'class' => 'form-inline']) }}
         {{ Form::label('month', __('report.view_monthly_label'), ['class' => 'control-label mr-1']) }}
-        {{ Form::select('month', get_months(), $startDate->format('m'), ['class' => 'form-control mr-1']) }}
+        {{ Form::select('month', ['00' => '-- All --'] + get_months(), request('month', $startDate->format('m')), ['class' => 'form-control mr-1']) }}
         {{ Form::select('year', get_years(), $startDate->format('Y'), ['class' => 'form-control mr-1']) }}
         <div class="form-group mt-4 mt-sm-0">
             {{ Form::submit(__('report.view_report'), ['class' => 'btn btn-info mr-1']) }}
             {{ link_to_route('reports.finance.categorized', __('report.this_month'), [], ['class' => 'btn btn-secondary mr-1']) }}
             {{ link_to_route('reports.finance.categorized_pdf', __('report.export_pdf'), ['year' => $startDate->format('Y'), 'month' => $startDate->format('m')], ['class' => 'btn btn-secondary mr-1']) }}
         </div>
-        <div class="form-group">
-            @livewire('prev-month-button', ['routeName' => 'reports.finance.categorized', 'buttonClass' => 'btn btn-secondary mr-1'])
-            @livewire('next-month-button', ['routeName' => 'reports.finance.categorized', 'buttonClass' => 'btn btn-secondary'])
-        </div>
+        @if (request('month') != '00')
+            <div class="form-group">
+                @livewire('prev-month-button', ['routeName' => 'reports.finance.categorized', 'buttonClass' => 'btn btn-secondary mr-1'])
+                @livewire('next-month-button', ['routeName' => 'reports.finance.categorized', 'buttonClass' => 'btn btn-secondary'])
+            </div>
+        @endif
         {{ Form::close() }}
     </div>
 </div>

--- a/resources/views/reports/finance/in_months/categorized.blade.php
+++ b/resources/views/reports/finance/in_months/categorized.blade.php
@@ -1,6 +1,6 @@
 @extends('layouts.reports')
 
-@section('subtitle', __('report.categorized_transactions', ['year_month' => $currentMonthEndDate->isoFormat('MMMM Y')]))
+@section('subtitle', __('report.categorized_transactions'))
 
 @section('content-report')
 
@@ -14,9 +14,14 @@
 <div class="page-header mt-0">
     <h1 class="page-title mb-4">
         @if (isset(auth()->activeBook()->report_titles['finance_categorized']))
-            {{ auth()->activeBook()->report_titles['finance_categorized'] }} - {{ $currentMonthEndDate->isoFormat('MMMM Y') }}
+            {{ auth()->activeBook()->report_titles['finance_categorized'] }}
         @else
-            {{ __('report.categorized_transactions') }} - {{ $currentMonthEndDate->isoFormat('MMMM Y') }}
+            {{ __('report.categorized_transactions') }}
+        @endif
+        @if (request('month') != '00')
+            - {{ $currentMonthEndDate->isoFormat('MMMM Y') }}
+        @else
+            - {{ $currentMonthEndDate->isoFormat('Y') }}
         @endif
 
         @if (!request('action'))
@@ -38,7 +43,7 @@
         <div class="form-group mt-4 mt-sm-0">
             {{ Form::submit(__('report.view_report'), ['class' => 'btn btn-info mr-1']) }}
             {{ link_to_route('reports.finance.categorized', __('report.this_month'), [], ['class' => 'btn btn-secondary mr-1']) }}
-            {{ link_to_route('reports.finance.categorized_pdf', __('report.export_pdf'), ['year' => $startDate->format('Y'), 'month' => $startDate->format('m')], ['class' => 'btn btn-secondary mr-1']) }}
+            {{ link_to_route('reports.finance.categorized_pdf', __('report.export_pdf'), ['year' => $startDate->format('Y'), 'month' => request('month', $startDate->format('m'))], ['class' => 'btn btn-secondary mr-1']) }}
         </div>
         @if (request('month') != '00')
             <div class="form-group">

--- a/resources/views/reports/finance/in_months/categorized.blade.php
+++ b/resources/views/reports/finance/in_months/categorized.blade.php
@@ -38,7 +38,7 @@
     <div class="page-options d-flex">
         {{ Form::open(['method' => 'get', 'class' => 'form-inline']) }}
         {{ Form::label('month', __('report.view_monthly_label'), ['class' => 'control-label mr-1']) }}
-        {{ Form::select('month', ['00' => '-- All --'] + get_months(), request('month', $startDate->format('m')), ['class' => 'form-control mr-1']) }}
+        {{ Form::select('month', ['00' => '-- '.__('app.all').' --'] + get_months(), request('month', $startDate->format('m')), ['class' => 'form-control mr-1']) }}
         {{ Form::select('year', get_years(), $startDate->format('Y'), ['class' => 'form-control mr-1']) }}
         <div class="form-group mt-4 mt-sm-0">
             {{ Form::submit(__('report.view_report'), ['class' => 'btn btn-info mr-1']) }}

--- a/resources/views/reports/finance/in_months/categorized_pdf.blade.php
+++ b/resources/views/reports/finance/in_months/categorized_pdf.blade.php
@@ -1,6 +1,6 @@
 @extends('layouts.print')
 
-@section('title', __('report.categorized_transactions', ['year_month' => $currentMonthEndDate->isoFormat('MMMM Y')]))
+@section('title', __('report.categorized_transactions'))
 
 @section('content')
 {{-- ref: https://github.com/niklasravnsborg/laravel-pdf#headers-and-footers --}}
@@ -9,9 +9,14 @@
 
     <h2 class="text-center strong">
         @if (isset(auth()->activeBook()->report_titles['finance_categorized']))
-            {{ auth()->activeBook()->report_titles['finance_categorized'] }} - {{ $currentMonthEndDate->isoFormat('MMMM Y') }}
+            {{ auth()->activeBook()->report_titles['finance_categorized'] }}
         @else
-            {{ __('report.categorized_transactions') }} - {{ $currentMonthEndDate->isoFormat('MMMM Y') }}
+            {{ __('report.categorized_transactions') }}
+        @endif
+        @if (request('month') != '00')
+            - {{ $currentMonthEndDate->isoFormat('MMMM Y') }}
+        @else
+            - {{ $currentMonthEndDate->isoFormat('Y') }}
         @endif
     </h2>
 </htmlpageheader>

--- a/resources/views/reports/finance/in_months/detailed.blade.php
+++ b/resources/views/reports/finance/in_months/detailed.blade.php
@@ -1,6 +1,6 @@
 @extends('layouts.reports')
 
-@section('subtitle', __('report.weekly', ['year_month' => $currentMonthEndDate->isoFormat('MMMM Y')]))
+@section('subtitle', __('report.weekly'))
 
 @section('content-report')
 
@@ -14,9 +14,14 @@
 <div class="page-header mt-0">
     <h1 class="page-title mb-4">
         @if (isset(auth()->activeBook()->report_titles['finance_detailed']))
-            {{ auth()->activeBook()->report_titles['finance_detailed'] }} - {{ $currentMonthEndDate->isoFormat('MMMM Y') }}
+            {{ auth()->activeBook()->report_titles['finance_detailed'] }}
         @else
-            {{ __('report.weekly') }} - {{ $currentMonthEndDate->isoFormat('MMMM Y') }}
+            {{ __('report.weekly') }}
+        @endif
+        @if (request('month') != '00')
+            - {{ $currentMonthEndDate->isoFormat('MMMM Y') }}
+        @else
+            - {{ $currentMonthEndDate->isoFormat('Y') }}
         @endif
 
         @can('update', auth()->activeBook())
@@ -36,7 +41,7 @@
         <div class="form-group mt-4 mt-sm-0">
             {{ Form::submit(__('report.view_report'), ['class' => 'btn btn-info mr-1']) }}
             {{ link_to_route('reports.finance.detailed', __('report.this_month'), [], ['class' => 'btn btn-secondary mr-1']) }}
-            {{ link_to_route('reports.finance.detailed_pdf', __('report.export_pdf'), ['year' => $startDate->format('Y'), 'month' => $startDate->format('m')], ['class' => 'btn btn-secondary mr-1']) }}
+            {{ link_to_route('reports.finance.detailed_pdf', __('report.export_pdf'), ['year' => $startDate->format('Y'), 'month' => request('month', $startDate->format('m'))], ['class' => 'btn btn-secondary mr-1']) }}
         </div>
         @if (request('month') != '00')
             <div class="form-group">

--- a/resources/views/reports/finance/in_months/detailed.blade.php
+++ b/resources/views/reports/finance/in_months/detailed.blade.php
@@ -31,17 +31,19 @@
     <div class="page-options d-flex">
         {{ Form::open(['method' => 'get', 'class' => 'form-inline']) }}
         {{ Form::label('month', __('report.view_monthly_label'), ['class' => 'control-label mr-1']) }}
-        {{ Form::select('month', get_months(), $startDate->format('m'), ['class' => 'form-control mr-1']) }}
+        {{ Form::select('month', ['00' => '-- All --'] + get_months(), request('month', $startDate->format('m')), ['class' => 'form-control mr-1']) }}
         {{ Form::select('year', get_years(), $startDate->format('Y'), ['class' => 'form-control mr-1']) }}
         <div class="form-group mt-4 mt-sm-0">
             {{ Form::submit(__('report.view_report'), ['class' => 'btn btn-info mr-1']) }}
             {{ link_to_route('reports.finance.detailed', __('report.this_month'), [], ['class' => 'btn btn-secondary mr-1']) }}
             {{ link_to_route('reports.finance.detailed_pdf', __('report.export_pdf'), ['year' => $startDate->format('Y'), 'month' => $startDate->format('m')], ['class' => 'btn btn-secondary mr-1']) }}
         </div>
-        <div class="form-group">
-            @livewire('prev-month-button', ['routeName' => 'reports.finance.detailed', 'buttonClass' => 'btn btn-secondary mr-1'])
-            @livewire('next-month-button', ['routeName' => 'reports.finance.detailed', 'buttonClass' => 'btn btn-secondary'])
-        </div>
+        @if (request('month') != '00')
+            <div class="form-group">
+                @livewire('prev-month-button', ['routeName' => 'reports.finance.detailed', 'buttonClass' => 'btn btn-secondary mr-1'])
+                @livewire('next-month-button', ['routeName' => 'reports.finance.detailed', 'buttonClass' => 'btn btn-secondary'])
+            </div>
+        @endif
         {{ Form::close() }}
     </div>
 </div>

--- a/resources/views/reports/finance/in_months/detailed.blade.php
+++ b/resources/views/reports/finance/in_months/detailed.blade.php
@@ -36,7 +36,7 @@
     <div class="page-options d-flex">
         {{ Form::open(['method' => 'get', 'class' => 'form-inline']) }}
         {{ Form::label('month', __('report.view_monthly_label'), ['class' => 'control-label mr-1']) }}
-        {{ Form::select('month', ['00' => '-- All --'] + get_months(), request('month', $startDate->format('m')), ['class' => 'form-control mr-1']) }}
+        {{ Form::select('month', ['00' => '-- '.__('app.all').' --'] + get_months(), request('month', $startDate->format('m')), ['class' => 'form-control mr-1']) }}
         {{ Form::select('year', get_years(), $startDate->format('Y'), ['class' => 'form-control mr-1']) }}
         <div class="form-group mt-4 mt-sm-0">
             {{ Form::submit(__('report.view_report'), ['class' => 'btn btn-info mr-1']) }}

--- a/resources/views/reports/finance/in_months/detailed_pdf.blade.php
+++ b/resources/views/reports/finance/in_months/detailed_pdf.blade.php
@@ -1,6 +1,6 @@
 @extends('layouts.print')
 
-@section('title', __('report.weekly', ['year_month' => $currentMonthEndDate->isoFormat('MMMM Y')]))
+@section('title', __('report.weekly'))
 
 @section('content')
 <htmlpageheader name="wpHeader">
@@ -8,9 +8,14 @@
 
     <h2 class="text-center strong">
         @if (isset(auth()->activeBook()->report_titles['finance_detailed']))
-            {{ auth()->activeBook()->report_titles['finance_detailed'] }} - {{ $currentMonthEndDate->isoFormat('MMMM Y') }}
+            {{ auth()->activeBook()->report_titles['finance_detailed'] }}
         @else
-            {{ __('report.weekly') }} - {{ $currentMonthEndDate->isoFormat('MMMM Y') }}
+            {{ __('report.weekly') }}
+        @endif
+        @if (request('month') != '00')
+            - {{ $currentMonthEndDate->isoFormat('MMMM Y') }}
+        @else
+            - {{ $currentMonthEndDate->isoFormat('Y') }}
         @endif
     </h2>
 </htmlpageheader>

--- a/resources/views/reports/finance/in_months/summary.blade.php
+++ b/resources/views/reports/finance/in_months/summary.blade.php
@@ -1,6 +1,6 @@
 @extends('layouts.reports')
 
-@section('subtitle', __('report.monthly', ['year_month' => $currentMonthEndDate->isoFormat('MMMM Y')]))
+@section('subtitle', __('report.monthly'))
 
 @section('content-report')
 
@@ -14,9 +14,14 @@
 <div class="page-header mt-0">
     <h1 class="page-title mb-4">
         @if (isset(auth()->activeBook()->report_titles['finance_summary']))
-            {{ auth()->activeBook()->report_titles['finance_summary'] }} - {{ $currentMonthEndDate->isoFormat('MMMM Y') }}
+            {{ auth()->activeBook()->report_titles['finance_summary'] }}
         @else
-            {{ __('report.monthly') }} - {{ $currentMonthEndDate->isoFormat('MMMM Y') }}
+            {{ __('report.monthly') }}
+        @endif
+        @if (request('month') != '00')
+            - {{ $currentMonthEndDate->isoFormat('MMMM Y') }}
+        @else
+            - {{ $currentMonthEndDate->isoFormat('Y') }}
         @endif
 
         @can('update', auth()->activeBook())
@@ -36,7 +41,7 @@
         <div class="form-group mt-4 mt-sm-0">
             {{ Form::submit(__('report.view_report'), ['class' => 'btn btn-info mr-1']) }}
             {{ link_to_route('reports.finance.summary', __('report.this_month'), [], ['class' => 'btn btn-secondary mr-1']) }}
-            {{ link_to_route('reports.finance.summary_pdf', __('report.export_pdf'), ['year' => $startDate->format('Y'), 'month' => $startDate->format('m')], ['class' => 'btn btn-secondary mr-1']) }}
+            {{ link_to_route('reports.finance.summary_pdf', __('report.export_pdf'), ['year' => $startDate->format('Y'), 'month' => request('month', $startDate->format('m'))], ['class' => 'btn btn-secondary mr-1']) }}
         </div>
         @if (request('month') != '00')
             <div class="form-group">

--- a/resources/views/reports/finance/in_months/summary.blade.php
+++ b/resources/views/reports/finance/in_months/summary.blade.php
@@ -31,17 +31,19 @@
     <div class="page-options d-flex">
         {{ Form::open(['method' => 'get', 'class' => 'form-inline']) }}
         {{ Form::label('month', __('report.view_monthly_label'), ['class' => 'control-label mr-1']) }}
-        {{ Form::select('month', get_months(), $startDate->format('m'), ['class' => 'form-control mr-1']) }}
+        {{ Form::select('month', ['00' => '-- All --'] + get_months(), request('month', $startDate->format('m')), ['class' => 'form-control mr-1']) }}
         {{ Form::select('year', get_years(), $startDate->format('Y'), ['class' => 'form-control mr-1']) }}
         <div class="form-group mt-4 mt-sm-0">
             {{ Form::submit(__('report.view_report'), ['class' => 'btn btn-info mr-1']) }}
             {{ link_to_route('reports.finance.summary', __('report.this_month'), [], ['class' => 'btn btn-secondary mr-1']) }}
             {{ link_to_route('reports.finance.summary_pdf', __('report.export_pdf'), ['year' => $startDate->format('Y'), 'month' => $startDate->format('m')], ['class' => 'btn btn-secondary mr-1']) }}
         </div>
-        <div class="form-group">
-            @livewire('prev-month-button', ['routeName' => 'reports.finance.summary', 'buttonClass' => 'btn btn-secondary mr-1'])
-            @livewire('next-month-button', ['routeName' => 'reports.finance.summary', 'buttonClass' => 'btn btn-secondary'])
-        </div>
+        @if (request('month') != '00')
+            <div class="form-group">
+                @livewire('prev-month-button', ['routeName' => 'reports.finance.summary', 'buttonClass' => 'btn btn-secondary mr-1'])
+                @livewire('next-month-button', ['routeName' => 'reports.finance.summary', 'buttonClass' => 'btn btn-secondary'])
+            </div>
+        @endif
         {{ Form::close() }}
     </div>
 </div>

--- a/resources/views/reports/finance/in_months/summary.blade.php
+++ b/resources/views/reports/finance/in_months/summary.blade.php
@@ -36,7 +36,7 @@
     <div class="page-options d-flex">
         {{ Form::open(['method' => 'get', 'class' => 'form-inline']) }}
         {{ Form::label('month', __('report.view_monthly_label'), ['class' => 'control-label mr-1']) }}
-        {{ Form::select('month', ['00' => '-- All --'] + get_months(), request('month', $startDate->format('m')), ['class' => 'form-control mr-1']) }}
+        {{ Form::select('month', ['00' => '-- '.__('app.all').' --'] + get_months(), request('month', $startDate->format('m')), ['class' => 'form-control mr-1']) }}
         {{ Form::select('year', get_years(), $startDate->format('Y'), ['class' => 'form-control mr-1']) }}
         <div class="form-group mt-4 mt-sm-0">
             {{ Form::submit(__('report.view_report'), ['class' => 'btn btn-info mr-1']) }}

--- a/resources/views/reports/finance/in_months/summary_pdf.blade.php
+++ b/resources/views/reports/finance/in_months/summary_pdf.blade.php
@@ -1,6 +1,6 @@
 @extends('layouts.print')
 
-@section('title', __('report.monthly', ['year_month' => $currentMonthEndDate->isoFormat('MMMM Y')]))
+@section('title', __('report.monthly'))
 
 @section('content')
 <htmlpageheader name="wpHeader">
@@ -8,9 +8,14 @@
 
     <h2 class="text-center strong">
         @if (isset(auth()->activeBook()->report_titles['finance_summary']))
-            {{ auth()->activeBook()->report_titles['finance_summary'] }} - {{ $currentMonthEndDate->isoFormat('MMMM Y') }}
+            {{ auth()->activeBook()->report_titles['finance_summary'] }}
         @else
-            {{ __('report.monthly') }} - {{ $currentMonthEndDate->isoFormat('MMMM Y') }}
+            {{ __('report.monthly') }}
+        @endif
+        @if (request('month') != '00')
+            - {{ $currentMonthEndDate->isoFormat('MMMM Y') }}
+        @else
+            - {{ $currentMonthEndDate->isoFormat('Y') }}
         @endif
     </h2>
 </htmlpageheader>


### PR DESCRIPTION
## Deskripsi

Pada PR ini, kita melakukan improvement fitur laporan untuk buku kas dengan periode laporan perbulan, agar dapat dilihat laporan selama 1 tahun.

## Task Link

- Tidak ada

## Checklist

- [x] Update filter bulan: "Semua bulan" pada laporan internal (ringkasan, per kategori, rincian)
- [x] Update filter bulan: "Semua bulan" pada laporan publik (ringkasan, per kategori, rincian)
- [x] Penyesuaian judul laporan
- [x] Sembunyikan tombol navigasi "Bulan Sblm" dan "Bulan Brkt" jika dipilih semua bulan

## Screenshot

Contoh Laporan Tahun 2023

![screen_2024-03-31_002](https://github.com/buku-masjid/buku-masjid/assets/8721551/802e2a35-2253-46ba-bddc-1ee33c38e5a6)

Contoh Laporan Tahun 2024

![screen_2024-03-31_003](https://github.com/buku-masjid/buku-masjid/assets/8721551/084d3d58-7d50-4aac-b281-c38f8a7bf2a9)

