### PR TITLE
Penugasan Bendahara per Buku Kas

### DIFF
--- a/app/Http/Controllers/BookController.php
+++ b/app/Http/Controllers/BookController.php
@@ -101,6 +101,9 @@ class BookController extends Controller
             'sign_position_right' => ['nullable', 'string', 'max:20'],
             'sign_name_right' => ['nullable', 'string', 'max:30'],
         ]);
+        if ($request->user()->cannot('change-manager', $book)) {
+            unset($bookData['manager_id']);
+        }
         $book->update($bookData);
         $this->updateBookSettings($book, $bookData);
 

--- a/app/Http/Controllers/BookController.php
+++ b/app/Http/Controllers/BookController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\BankAccount;
 use App\Models\Book;
+use App\User;
 use Facades\App\Helpers\Setting;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
@@ -70,8 +71,9 @@ class BookController extends Controller
     {
         $this->authorize('update', $book);
         $bankAccounts = BankAccount::where('is_active', BankAccount::STATUS_ACTIVE)->pluck('name', 'id');
+        $financeUsers = User::where('role_id', User::ROLE_FINANCE)->pluck('name', 'id');
 
-        return view('books.edit', compact('book', 'bankAccounts'));
+        return view('books.edit', compact('book', 'bankAccounts', 'financeUsers'));
     }
 
     public function update(Request $request, Book $book)
@@ -87,6 +89,7 @@ class BookController extends Controller
             'budget' => ['nullable', 'numeric'],
             'report_periode_code' => ['required', Rule::in(Book::getConstants('REPORT_PERIODE'))],
             'start_week_day_code' => ['required', 'string'],
+            'manager_id' => ['nullable', 'exists:users,id'],
             'management_title' => ['nullable', 'string', 'max:20'],
             'acknowledgment_text_left' => ['nullable', 'string', 'max:20'],
             'sign_position_left' => ['nullable', 'string', 'max:20'],

--- a/app/Models/Book.php
+++ b/app/Models/Book.php
@@ -21,7 +21,7 @@ class Book extends Model
 
     protected $fillable = [
         'name', 'description', 'status_id', 'creator_id', 'bank_account_id', 'report_visibility_code', 'report_titles',
-        'budget', 'report_periode_code', 'start_week_day_code',
+        'budget', 'report_periode_code', 'start_week_day_code', 'manager_id',
     ];
     protected $casts = [
         'report_titles' => 'array',
@@ -30,6 +30,11 @@ class Book extends Model
     public function creator()
     {
         return $this->belongsTo(User::class)->withDefault(['name' => __('app.system')]);
+    }
+
+    public function manager()
+    {
+        return $this->belongsTo(User::class);
     }
 
     public function transactions()

--- a/app/Models/Book.php
+++ b/app/Models/Book.php
@@ -34,7 +34,7 @@ class Book extends Model
 
     public function manager()
     {
-        return $this->belongsTo(User::class);
+        return $this->belongsTo(User::class)->withDefault(['name' => __('book.admin_only')]);
     }
 
     public function transactions()

--- a/app/Policies/BookPolicy.php
+++ b/app/Policies/BookPolicy.php
@@ -28,6 +28,11 @@ class BookPolicy
             || ($user->role_id == User::ROLE_FINANCE && $book->manager_id == $user->id);
     }
 
+    public function changeManager(User $user, Book $book): bool
+    {
+        return $user->role_id == User::ROLE_ADMIN;
+    }
+
     public function delete(User $user, Book $book): bool
     {
         if ($book->creator_id == null) {

--- a/app/Policies/BookPolicy.php
+++ b/app/Policies/BookPolicy.php
@@ -24,7 +24,8 @@ class BookPolicy
 
     public function update(User $user, Book $book): bool
     {
-        return in_array($user->role_id, [User::ROLE_ADMIN, User::ROLE_FINANCE]);
+        return $user->role_id == User::ROLE_ADMIN
+            || ($user->role_id == User::ROLE_FINANCE && $book->manager_id == $user->id);
     }
 
     public function delete(User $user, Book $book): bool
@@ -32,7 +33,7 @@ class BookPolicy
         if ($book->creator_id == null) {
             return false;
         }
-        if (!in_array($user->role_id, [User::ROLE_ADMIN, User::ROLE_FINANCE])) {
+        if (!in_array($user->role_id, [User::ROLE_ADMIN])) {
             return false;
         }
         if (!in_array($user->role_id, [User::ROLE_ADMIN]) && $book->creator_id != $user->id) {
@@ -44,11 +45,11 @@ class BookPolicy
 
     public function manageTransactions(User $user, Book $book): bool
     {
-        return $book->status_id == Book::STATUS_ACTIVE;
+        return $this->update($user, $book) && $book->status_id == Book::STATUS_ACTIVE;
     }
 
     public function manageCategories(User $user, Book $book): bool
     {
-        return $book->status_id == Book::STATUS_ACTIVE;
+        return $this->update($user, $book) && $book->status_id == Book::STATUS_ACTIVE;
     }
 }

--- a/database/migrations/2018_05_01_165137_create_books_table.php
+++ b/database/migrations/2018_05_01_165137_create_books_table.php
@@ -15,6 +15,7 @@ return new class extends Migration
             $table->string('description')->nullable();
             $table->text('report_titles')->nullable();
             $table->unsignedInteger('creator_id')->nullable();
+            $table->unsignedInteger('manager_id')->nullable();
             $table->string('report_visibility_code', 10)->default(Book::REPORT_VISIBILITY_INTERNAL);
             $table->unsignedTinyInteger('status_id')->default(Book::STATUS_ACTIVE);
             $table->unsignedInteger('bank_account_id')->nullable();
@@ -24,6 +25,7 @@ return new class extends Migration
             $table->timestamps();
 
             $table->foreign('creator_id')->references('id')->on('users')->onDelete('restrict');
+            $table->foreign('manager_id')->references('id')->on('users')->onDelete('restrict');
         });
     }
 

--- a/database/migrations/2024_04_22_170510_add_manager_id_on_books_table.php
+++ b/database/migrations/2024_04_22_170510_add_manager_id_on_books_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (!Schema::hasColumn('books', 'manager_id')) {
+            Schema::table('books', function (Blueprint $table) {
+                $table->unsignedInteger('manager_id')->nullable()->after('creator_id');
+                $table->foreign('manager_id')->references('id')->on('users')->onDelete('restrict');
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (Schema::hasColumn('books', 'manager_id')) {
+            Schema::table('books', function (Blueprint $table) {
+                $table->dropForeign('books_manager_id_foreign');
+                $table->dropColumn('manager_id');
+            });
+        }
+    }
+};

--- a/resources/lang/en/book.php
+++ b/resources/lang/en/book.php
@@ -17,6 +17,7 @@ return [
     'back_to_index' => 'Back to Cash Book List',
     'management_title' => 'Management Title',
     'management_title_info_text' => 'Eg: Ramadhan committee, Qurban committee',
+    'admin_only' => 'Admin Only',
 
     // Actions
     'create' => 'Create new Cash Book',

--- a/resources/lang/en/book.php
+++ b/resources/lang/en/book.php
@@ -45,6 +45,8 @@ return [
     'report_visibility' => 'Report Visibility',
     'report_visibility_public' => 'Public',
     'report_visibility_internal' => 'Internal',
+    'manager' => 'Finance User',
+    'manager_info_text' => 'Finance user will have write access to this book.',
 
     // Relations
     'transactions' => 'Cash Book Transactions',

--- a/resources/lang/id/book.php
+++ b/resources/lang/id/book.php
@@ -45,6 +45,8 @@ return [
     'report_visibility' => 'Visibilitas Laporan',
     'report_visibility_public' => 'Publik',
     'report_visibility_internal' => 'Internal',
+    'manager' => 'Pengelola/Bendahara',
+    'manager_info_text' => 'User bendahara dapat mengisi dan mengubah data buku kas ini.',
 
     // Relations
     'transactions' => 'List Transaksi Buku Kas',

--- a/resources/lang/id/book.php
+++ b/resources/lang/id/book.php
@@ -17,6 +17,7 @@ return [
     'back_to_index' => 'Kembali ke daftar Buku Kas',
     'management_title' => 'Kepengurusan/Kepanitiaan',
     'management_title_info_text' => 'Misal: Takmir Ramadhan, Panitia Qurban',
+    'admin_only' => 'Hanya Admin',
 
     // Actions
     'create' => 'Input Buku Kas Baru',
@@ -46,7 +47,7 @@ return [
     'report_visibility_public' => 'Publik',
     'report_visibility_internal' => 'Internal',
     'manager' => 'Pengelola/Bendahara',
-    'manager_info_text' => 'User bendahara dapat mengisi dan mengubah data buku kas ini.',
+    'manager_info_text' => 'User bendahara dapat mengelola dan mengubah data buku kas ini.',
 
     // Relations
     'transactions' => 'List Transaksi Buku Kas',

--- a/resources/views/books/edit.blade.php
+++ b/resources/views/books/edit.blade.php
@@ -132,11 +132,15 @@
                             'placeholder' => __('report.management'),
                             'info' => ['text' => __('book.management_title_info_text')],
                         ]) !!}
-                        {!! FormField::select('manager_id', $financeUsers, [
-                            'label' => __('book.manager'),
-                            'placeholder' => __('book.admin_only'),
-                            'info' => ['text' => __('book.manager_info_text')],
-                        ]) !!}
+                        @can('change-manager', $book)
+                            {!! FormField::select('manager_id', $financeUsers, [
+                                'label' => __('book.manager'),
+                                'placeholder' => __('book.admin_only'),
+                                'info' => ['text' => __('book.manager_info_text')],
+                            ]) !!}
+                        @else
+                            {!! FormField::textDisplay(__('book.manager'), $book->manager->name) !!}
+                        @endcan
                     </div>
                 </div>
                 <legend>{{ __('report.signatures') }}</legend>

--- a/resources/views/books/edit.blade.php
+++ b/resources/views/books/edit.blade.php
@@ -1,12 +1,17 @@
-@extends('layouts.app')
+@extends('layouts.settings')
 
 @section('title', __('book.edit'))
 
-@section('content')
+@section('content_settings')
 <div class="row justify-content-center">
     @if (request('action') == 'delete' && $book)
     <div class="col-md-6">
         @can('delete', $book)
+            <div class="page-header">
+                <h1 class="page-title">{{ $book->name }}</h1>
+                <div class="page-subtitle">{{ __('book.delete') }}</div>
+                <div class="page-options d-flex"></div>
+            </div>
             <div class="card">
                 <div class="card-header">{{ __('book.delete') }}</div>
                 <div class="card-body">
@@ -53,8 +58,14 @@
     </div>
     @else
     <div class="col-md-10">
+        <div class="page-header">
+            <h1 class="page-title">{{ $book->name }}</h1>
+            <div class="page-subtitle">{{ __('book.edit') }}</div>
+            <div class="page-options d-flex">
+                {{ link_to_route('books.show', __('app.cancel'), [$book], ['class' => 'btn btn-secondary float-right']) }}
+            </div>
+        </div>
         <div class="card">
-            <div class="card-header">{{ __('book.edit') }}</div>
             {{ Form::model($book, ['route' => ['books.update', $book], 'method' => 'patch']) }}
             <div class="card-body">
                 <div class="row">
@@ -120,6 +131,10 @@
                             'label' => __('book.management_title'),
                             'placeholder' => __('report.management'),
                             'info' => ['text' => __('book.management_title_info_text')],
+                        ]) !!}
+                        {!! FormField::select('manager_id', $financeUsers, [
+                            'label' => __('book.manager'),
+                            'info' => ['text' => __('book.manager_info_text')],
                         ]) !!}
                     </div>
                 </div>

--- a/resources/views/books/edit.blade.php
+++ b/resources/views/books/edit.blade.php
@@ -134,6 +134,7 @@
                         ]) !!}
                         {!! FormField::select('manager_id', $financeUsers, [
                             'label' => __('book.manager'),
+                            'placeholder' => __('book.admin_only'),
                             'info' => ['text' => __('book.manager_info_text')],
                         ]) !!}
                     </div>

--- a/resources/views/books/show.blade.php
+++ b/resources/views/books/show.blade.php
@@ -23,6 +23,7 @@
                         <td>{{ __('book.management_title') }}</td>
                         <td>{{ Setting::for($book)->get('management_title', __('report.management')) }}</td>
                     </tr>
+                    <tr><td>{{ __('book.manager') }}</td><td>{{ optional($book->manager)->name }}</td></tr>
                     <tr><td>{{ __('book.description') }}</td><td>{{ $book->description }}</td></tr>
                     <tr><td>{{ __('bank_account.bank_account') }}</td><td>{{ $book->bankAccount->name }}</td></tr>
                     <tr><td>{{ __('book.budget') }}</td><td>{{ format_number($book->budget ?: 0) }}</td></tr>

--- a/resources/views/books/show.blade.php
+++ b/resources/views/books/show.blade.php
@@ -23,7 +23,7 @@
                         <td>{{ __('book.management_title') }}</td>
                         <td>{{ Setting::for($book)->get('management_title', __('report.management')) }}</td>
                     </tr>
-                    <tr><td>{{ __('book.manager') }}</td><td>{{ optional($book->manager)->name }}</td></tr>
+                    <tr><td>{{ __('book.manager') }}</td><td>{{ $book->manager->name }}</td></tr>
                     <tr><td>{{ __('book.description') }}</td><td>{{ $book->description }}</td></tr>
                     <tr><td>{{ __('bank_account.bank_account') }}</td><td>{{ $book->bankAccount->name }}</td></tr>
                     <tr><td>{{ __('book.budget') }}</td><td>{{ format_number($book->budget ?: 0) }}</td></tr>

--- a/tests/Feature/Books/ManageBookTest.php
+++ b/tests/Feature/Books/ManageBookTest.php
@@ -81,10 +81,11 @@ class ManageBookTest extends TestCase
     /** @test */
     public function user_can_edit_a_book()
     {
-        $user = $this->loginAsUser();
+        $adminUser = $this->loginAsUser();
+        $financeUser = $this->createUser('finance');
         $book = factory(Book::class)->create([
             'name' => 'Testing 123',
-            'creator_id' => $user->id,
+            'creator_id' => $adminUser->id,
             'report_visibility_code' => Book::REPORT_VISIBILITY_INTERNAL,
         ]);
         $bankAccount = factory(BankAccount::class)->create();
@@ -98,6 +99,7 @@ class ManageBookTest extends TestCase
             'description' => 'Book 1 description',
             'status_id' => Book::STATUS_ACTIVE,
             'bank_account_id' => $bankAccount->id,
+            'manager_id' => $financeUser->id,
             'report_visibility_code' => Book::REPORT_VISIBILITY_PUBLIC,
             'budget' => 1000000,
             'report_periode_code' => Book::REPORT_PERIODE_IN_WEEKS,
@@ -125,6 +127,7 @@ class ManageBookTest extends TestCase
             'budget' => 1000000,
             'report_periode_code' => Book::REPORT_PERIODE_IN_WEEKS,
             'start_week_day_code' => 'friday',
+            'manager_id' => $financeUser->id,
         ]);
 
         $this->seeInDatabase('settings', [

--- a/tests/Feature/Books/ManageBookTest.php
+++ b/tests/Feature/Books/ManageBookTest.php
@@ -195,6 +195,23 @@ class ManageBookTest extends TestCase
     }
 
     /** @test */
+    public function finance_user_can_edit_a_book_except_manager_id_attribute()
+    {
+        $financeUser = $this->loginAsUser('finance');
+        $adminUser = $this->createUser('admin');
+        $otherFinanceUser = $this->createUser('finance');
+        $book = factory(Book::class)->create([
+            'name' => 'Testing 123',
+            'creator_id' => $adminUser->id,
+            'manager_id' => $financeUser->id,
+            'report_visibility_code' => Book::REPORT_VISIBILITY_INTERNAL,
+        ]);
+
+        $this->visitRoute('books.edit', $book);
+        $this->dontSeeElement('select', ['name' => 'manager_id']);
+    }
+
+    /** @test */
     public function user_can_delete_a_book()
     {
         $user = $this->loginAsUser();

--- a/tests/Unit/Models/BookTest.php
+++ b/tests/Unit/Models/BookTest.php
@@ -25,6 +25,16 @@ class BookTest extends TestCase
     }
 
     /** @test */
+    public function a_book_has_belongs_to_manager_relation()
+    {
+        $financeUser = $this->createUser('finance');
+        $book = factory(Book::class)->make(['manager_id' => $financeUser->id]);
+
+        $this->assertInstanceOf(User::class, $book->manager);
+        $this->assertEquals($book->manager_id, $book->manager->id);
+    }
+
+    /** @test */
     public function a_book_can_be_belongs_to_system()
     {
         $book = factory(Book::class)->create(['creator_id' => null]);

--- a/tests/Unit/Models/BookTest.php
+++ b/tests/Unit/Models/BookTest.php
@@ -28,9 +28,16 @@ class BookTest extends TestCase
     public function a_book_has_belongs_to_manager_relation()
     {
         $financeUser = $this->createUser('finance');
-        $book = factory(Book::class)->make(['manager_id' => $financeUser->id]);
+        $book = factory(Book::class)->create();
+
+        $this->assertEquals(__('book.admin_only'), $book->manager->name);
+
+        $book->manager_id = $financeUser->id;
+        $book->save();
+        $book = $book->fresh();
 
         $this->assertInstanceOf(User::class, $book->manager);
+        $this->assertEquals($financeUser->name, $book->manager->name);
         $this->assertEquals($book->manager_id, $book->manager->id);
     }
 

--- a/tests/Unit/Policies/BookPolicyTest.php
+++ b/tests/Unit/Policies/BookPolicyTest.php
@@ -57,7 +57,7 @@ class BookPolicyTest extends TestCase
     }
 
     /** @test */
-    public function admin_can_update_book()
+    public function admin_and_finance_user_can_update_book()
     {
         $admin = $this->createUser('admin');
         $chairman = $this->createUser('chairman');
@@ -86,6 +86,24 @@ class BookPolicyTest extends TestCase
         $this->assertTrue($admin->can('update', $book));
         $this->assertTrue($finance->can('update', $book));
         $this->assertFalse($finance->can('update', $othersBook));
+    }
+
+    /** @test */
+    public function only_admin_can_update_book_manager_attribute()
+    {
+        $admin = $this->createUser('admin');
+        $chairman = $this->createUser('chairman');
+        $secretary = $this->createUser('secretary');
+        $finance = $this->createUser('finance');
+
+        $book = factory(Book::class)->create(['creator_id' => $admin->id, 'manager_id' => $finance->id]);
+        $othersBook = factory(Book::class)->create();
+
+        $this->assertTrue($admin->can('change-manager', $book));
+        $this->assertTrue($admin->can('change-manager', $othersBook));
+        $this->assertFalse($chairman->can('change-manager', $book));
+        $this->assertFalse($secretary->can('change-manager', $book));
+        $this->assertFalse($finance->can('change-manager', $book));
     }
 
     /** @test */

--- a/tests/Unit/Policies/BookPolicyTest.php
+++ b/tests/Unit/Policies/BookPolicyTest.php
@@ -57,7 +57,7 @@ class BookPolicyTest extends TestCase
     }
 
     /** @test */
-    public function admin_and_finance_can_update_book()
+    public function admin_can_update_book()
     {
         $admin = $this->createUser('admin');
         $chairman = $this->createUser('chairman');
@@ -71,11 +71,25 @@ class BookPolicyTest extends TestCase
         $this->assertTrue($admin->can('update', $othersBook));
         $this->assertFalse($chairman->can('update', $book));
         $this->assertFalse($secretary->can('update', $book));
-        $this->assertTrue($finance->can('update', $book));
+        $this->assertFalse($finance->can('update', $book));
     }
 
     /** @test */
-    public function admin_and_finance_can_delete_book()
+    public function finance_user_can_update_book_assigned_to_them()
+    {
+        $admin = $this->createUser('admin');
+        $finance = $this->createUser('finance');
+
+        $book = factory(Book::class)->create(['creator_id' => $admin->id, 'manager_id' => $finance->id]);
+        $othersBook = factory(Book::class)->create();
+
+        $this->assertTrue($admin->can('update', $book));
+        $this->assertTrue($finance->can('update', $book));
+        $this->assertFalse($finance->can('update', $othersBook));
+    }
+
+    /** @test */
+    public function admin_can_delete_book()
     {
         $admin = $this->createUser('admin');
         $chairman = $this->createUser('chairman');
@@ -95,7 +109,7 @@ class BookPolicyTest extends TestCase
         $this->assertFalse($secretary->can('delete', $adminBook));
 
         $this->assertFalse($finance->can('delete', $adminBook));
-        $this->assertTrue($finance->can('delete', $financeBook));
+        $this->assertFalse($finance->can('delete', $financeBook));
         $this->assertFalse($finance->can('delete', $systemBook));
     }
 
@@ -105,12 +119,14 @@ class BookPolicyTest extends TestCase
         $admin = $this->createUser('admin');
         $finance = $this->createUser('finance');
 
-        $book = factory(Book::class)->create(['creator_id' => $admin->id]);
+        $book = factory(Book::class)->create(['creator_id' => $admin->id, 'manager_id' => $finance->id]);
+        $otherBook = factory(Book::class)->create(['creator_id' => $admin->id]);
 
         $this->assertTrue($admin->can('manage-transactions', $book));
         $this->assertTrue($finance->can('manage-transactions', $book));
+        $this->assertFalse($finance->can('manage-transactions', $otherBook));
 
-        $inActiveBook = factory(Book::class)->create(['status_id' => Book::STATUS_INACTIVE]);
+        $inActiveBook = factory(Book::class)->create(['status_id' => Book::STATUS_INACTIVE, 'manager_id' => $finance->id]);
 
         $this->assertFalse($admin->can('manage-transactions', $inActiveBook));
         $this->assertFalse($finance->can('manage-transactions', $inActiveBook));
@@ -122,12 +138,14 @@ class BookPolicyTest extends TestCase
         $admin = $this->createUser('admin');
         $finance = $this->createUser('finance');
 
-        $book = factory(Book::class)->create(['creator_id' => $admin->id]);
+        $book = factory(Book::class)->create(['creator_id' => $admin->id, 'manager_id' => $finance->id]);
+        $otherBook = factory(Book::class)->create(['creator_id' => $admin->id]);
 
         $this->assertTrue($admin->can('manage-categories', $book));
         $this->assertTrue($finance->can('manage-categories', $book));
+        $this->assertFalse($finance->can('manage-categories', $otherBook));
 
-        $inActiveBook = factory(Book::class)->create(['status_id' => Book::STATUS_INACTIVE]);
+        $inActiveBook = factory(Book::class)->create(['status_id' => Book::STATUS_INACTIVE, 'manager_id' => $finance->id]);
 
         $this->assertFalse($admin->can('manage-categories', $inActiveBook));
         $this->assertFalse($finance->can('manage-categories', $inActiveBook));


### PR DESCRIPTION
## Deskripsi

Pada PR ini, kita ingin membuat agar setiap buku kas dapat dikelola oleh pengurus/panitia kegiatan. Pengurus tersebut hanya dapat input dan edit data (transaksi dan kategori) sesuai buku kas yang ditugaskan kepadanya. Contoh kasus:

Di masjid ada bendahara umum, yang memegang buku kas masjid. Kemudian ketika ada kegiatan qurban/ramadhan, ada panitia khusus yang dibentuk lengkap dengan bendahara (orangnya dengan bendahara masjid). Kita ingin agar bendahara tersebut menggunakan sistem buku masjid, tetapi khusus untuk buku kas kegiatan itu saja. Bendahara tersebut tidak boleh mengutak atik buku kas lain (terutama kas operasional masjid).

Nah di fitur yang baru ini, kita dapat menentukan buku kas mana dipegang oleh bendahara mana. Ini untuk minimalisir salah input dibuku kas salah.

Alur penggunaan fiturnya kurang lebih seperti ini, ketika ada kegiatan baru:
1. Buat user dengan role Bendahara (kalau belum ada), misal namanya pak Abdullah
2. Buat 1 buku kas dengan memilih user bendahara pak Abdullah yang telah dibuat tadi.
3. Ketika pak Abdullah login, beliau memilih buku kas mana yang ingin digunakan.
4. Pak Abdullah dapat melihat buku kas lain, tetapi tidak dapat input/edit transaksi dan kategori
5. Pak Abdullah hanya dapat input/edit transaksi dan kategori sesuai dengan buku kas yang ditugaskan kepada beliau.
6. ~~Pak Abdullah tidak dapat melihat detail transaksi dengan kategori yang visibilitasnya Internal di buku kas lain (menjaga privasi antara pengurus masjid dengan kepanitiaan kegiatan).~~
7. ~~Pak Abdullah dapat melihat detail transaksi dengan kategori yang visibilitasnya Internal di buku kas yang ditugaskan kepada beliau.~~

## Task Link

- #69 

## Checklist

- [x] Penambahan kolom `books.manager_id` nullable.
- [x] Untuk books yang manager_id nya null, hanya administrator yang dapat mengelola datanya.
- [x] User bendahara dapat melihat semua buku yang tersedia di sistem
- [x] User bendahara hanya dapat mengelola data (transaksi dan kategori) pada buku kas yang ditugaskan padanya
- [x] ~~User bendahara hanya dapat melihat detail transaksi dengan kategori visibilitas internal, pada buku kas yang dikelolanya~~ (pending dulu)
- [x] ~~User admin dapat melihat seluruh detail transaksi~~ (pending dulu)
- [x] ~~User ketua dapat melihat seluruh detail transaksi~~ (pending dulu)
- [x] User bendahara tidak dapat mengubah Pengelola/Bendahara buku kas



## Screenshot

Edit buku kas, bisa memilih user bendahara yang akan mengelola buku kas.

![screen_2024-04-27_001](https://github.com/buku-masjid/buku-masjid/assets/8721551/c3e16ec7-f001-443a-9440-facc2a6fed27)

Detail buku kas menampilkan nama pengelola/user bendahara

![screen_2024-04-27_002](https://github.com/buku-masjid/buku-masjid/assets/8721551/4810106a-03be-4779-8aa8-f812efca6917)

Bendahara bisa edit buku kas tetapi tidak bisa mengubah nama pengelola/bendahara (karena hanya untu admin).

![screen_2024-04-28_001](https://github.com/buku-masjid/buku-masjid/assets/8721551/e132b3f7-59d7-40c1-9cac-17e0465c9946)