### PR TITLE
Menggunakan Laravel Passport untuk Request API Internal

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,12 @@ Aplikasi ini dapat diinstal pada server lokal maupun online dengan spesifikasi b
 ### Langkah Instalasi
 
 1. Clone repositori ini dengan perintah: `git clone https://github.com/buku-masjid/buku-masjid.git`
-2. Masuk ke direktori buku-masjid: `$ cd buku-masjid`
-3. Instal dependensi menggunakan: `$ composer install`
-4. Salin berkas `.env.example` ke `.env`: `$ cp .env.example .env`
-5. Generate kunci aplikasi: `$ php artisan key:generate`
-6. Buat database MySQL untuk aplikasi ini.
-7. Konfigurasi database dan pengaturan lainnya di berkas `.env`.
+1. Masuk ke direktori buku-masjid: `$ cd buku-masjid`
+1. Instal dependensi menggunakan: `$ composer install`
+1. Salin berkas `.env.example` ke `.env`: `$ cp .env.example .env`
+1. Generate kunci aplikasi: `$ php artisan key:generate`
+1. Buat database MySQL untuk aplikasi ini.
+1. Konfigurasi database dan pengaturan lainnya di berkas `.env`.
     ```
     APP_URL=http://localhost
     APP_TIMEZONE="Asia/Makassar"
@@ -75,11 +75,12 @@ Aplikasi ini dapat diinstal pada server lokal maupun online dengan spesifikasi b
     MONEY_DECIMAL_SEPARATOR=","
     MONEY_THOUSANDS_SEPARATOR="."
     ```
-8. Jalankan migrasi database: `$ php artisan migrate --seed`
-9. Buat kunci passport: `$ php artisan passport:keys`
-10. Buat tautan penyimpanan: `$ php artisan storage:link`
-11. Mulai server: `$ php artisan serve`
-12. Buka web browser dengan alamat web: http://localhost:8000, kemudian masuk dengan akun bawaan:
+1. Jalankan migrasi database: `$ php artisan migrate --seed`
+1. Buat kunci passport: `$ php artisan passport:keys`
+1. Buat access token client: `$ php artisan passport:client --personal --name="API Buku Masjid"`
+1. Buat tautan penyimpanan: `$ php artisan storage:link`
+1. Mulai server: `$ php artisan serve`
+1. Buka web browser dengan alamat web: http://localhost:8000, kemudian masuk dengan akun bawaan:
     ```
     email: admin@example.net
     password: password

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Auth;
 use App\Http\Controllers\Controller;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Session;
 
 class LoginController extends Controller
 {
@@ -55,6 +56,8 @@ class LoginController extends Controller
 
             return redirect()->route('login');
         }
+        $accessToken = $user->createToken('API Token')->accessToken;
+        Session::put('auth.access_token', $accessToken);
 
         flash(trans('auth.welcome', ['name' => $user->name]));
     }

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -55,6 +55,7 @@ class Kernel extends HttpKernel
     protected $routeMiddleware = [
         'auth' => \Illuminate\Auth\Middleware\Authenticate::class,
         'auth.basic' => \Illuminate\Auth\Middleware\AuthenticateWithBasicAuth::class,
+        'auth.grant_api_access' => \App\Http\Middleware\GrantApiAccess::class,
         'bindings' => \Illuminate\Routing\Middleware\SubstituteBindings::class,
         'can' => \Illuminate\Auth\Middleware\Authorize::class,
         'guest' => \App\Http\Middleware\RedirectIfAuthenticated::class,

--- a/app/Http/Middleware/GrantApiAccess.php
+++ b/app/Http/Middleware/GrantApiAccess.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Session;
+
+class GrantApiAccess
+{
+    public function handle($request, Closure $next, $guard = null)
+    {
+        if (!Auth::guard($guard)->check()) {
+            return $next($request);
+        }
+
+        if (Session::has('auth.access_token')) {
+            Auth::guard($guard)->user()->withAccessToken(Session::get('auth.access_token'));
+
+            return $next($request);
+        }
+
+        return $this->redirectToLoginPage($request, $guard);
+    }
+
+    private function redirectToLoginPage($request, $guard = null)
+    {
+        Auth::guard($guard)->logout();
+        $request->session()->flush();
+        $request->session()->regenerate();
+        flash(__('auth.api_token_expired'), 'error');
+
+        return redirect()->route('login');
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -10,6 +10,7 @@ use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Facades\View;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Passport\Guards\TokenGuard;
+use Laravel\Passport\Passport;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -68,6 +69,8 @@ class AppServiceProvider extends ServiceProvider
 
             return $view->with('activeBooks', $activeBooks);
         });
+
+        Passport::personalAccessTokensExpireIn(now()->addDay());
     }
 
     /**

--- a/resources/lang/en/auth.php
+++ b/resources/lang/en/auth.php
@@ -12,6 +12,7 @@ return [
     'user_inactive' => 'This user is in active.',
     'remember_me' => 'Remember Me',
     'have_account' => 'I have an account',
+    'api_token_expired' => 'API token expired.',
 
     // Password
     'change_password' => 'Change Password',

--- a/resources/lang/id/auth.php
+++ b/resources/lang/id/auth.php
@@ -12,6 +12,7 @@ return [
     'user_inactive' => 'User tidak aktif.',
     'remember_me' => 'Ingat Saya',
     'have_account' => 'Saya sudah mendaftar',
+    'api_token_expired' => 'API token kadaluarsa.',
 
     // Password
     'change_password' => 'Ganti Password',

--- a/resources/views/masjid_profile/edit.blade.php
+++ b/resources/views/masjid_profile/edit.blade.php
@@ -141,7 +141,7 @@
                         dataType: "json",
                         url: "{{ route('api.masjid_profile.image')}}",
                         headers: {
-                            'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')
+                            'Authorization': "Bearer {{ auth()->user()->token() }}"
                         },
                         data: {
                             '_token': $('meta[name="_token"]').attr('content'),

--- a/routes/api.php
+++ b/routes/api.php
@@ -47,8 +47,7 @@ Route::group(['middleware' => 'auth:api', 'as' => 'api.', 'namespace' => 'Api'],
     Route::apiResource('books', 'BookController')->names('books');
 });
 
-// Authentication with sessions, specifically for AJAX from Blade.
-Route::group(['middleware' => ['auth', 'web'], 'as' => 'api.'], function () {
+Route::group(['middleware' => ['auth:api'], 'as' => 'api.'], function () {
     /*
      * Masjid Profile Endpoints
      */

--- a/routes/web.php
+++ b/routes/web.php
@@ -102,7 +102,8 @@ Route::group(['middleware' => 'auth'], function () {
     Route::resource('lecturings', App\Http\Controllers\LecturingController::class);
 
     Route::get('masjid_profile', [App\Http\Controllers\MasjidProfileController::class, 'show'])->name('masjid_profile.show');
-    Route::get('masjid_profile/edit', [App\Http\Controllers\MasjidProfileController::class, 'edit'])->name('masjid_profile.edit');
+    Route::get('masjid_profile/edit', [App\Http\Controllers\MasjidProfileController::class, 'edit'])->name('masjid_profile.edit')
+        ->middleware('auth.grant_api_access');
     Route::patch('masjid_profile', [App\Http\Controllers\MasjidProfileController::class, 'update'])->name('masjid_profile.update');
 
     /*

--- a/tests/Feature/Api/MasjidProfileTest.php
+++ b/tests/Feature/Api/MasjidProfileTest.php
@@ -4,7 +4,9 @@ namespace Tests\Feature\Api;
 
 use Facades\App\Helpers\Setting;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
+use Laravel\Passport\Passport;
 use Tests\TestCase;
 
 class MasjidProfileTest extends TestCase
@@ -32,5 +34,30 @@ class MasjidProfileTest extends TestCase
             'google_maps_link' => $masjidGoogleMapsLink,
             'logo_image_url' => Storage::url($logoImageUrl),
         ]);
+    }
+
+    /** @test */
+    public function admin_can_update_masjid_logo_image()
+    {
+        $user = $this->createUser();
+        Passport::actingAs($user);
+        Storage::fake(config('filesystem.default'));
+
+        // Ref: https://www.geeksforgeeks.org/how-to-convert-an-image-to-base64-encoding-in-php/
+        $imageContent = file_get_contents(public_path('images/icons8-coins-16.png'));
+        $base64EncodedImage = 'data:image/png;base64,'.base64_encode($imageContent);
+
+        $this->postJson(route('api.masjid_profile.image'), [
+            'image' => $base64EncodedImage,
+        ]);
+
+        $this->seeInDatabase('settings', [
+            'model_id' => null,
+            'model_type' => null,
+            'key' => 'masjid_logo_path',
+        ]);
+
+        $masjidLogoPath = DB::table('settings')->where('key', 'masjid_logo_path')->first()->value;
+        Storage::assertExists($masjidLogoPath);
     }
 }

--- a/tests/Feature/Auth/LoginTest.php
+++ b/tests/Feature/Auth/LoginTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Auth;
 
 use App\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Passport\ClientRepository;
 use Tests\TestCase;
 
 class LoginTest extends TestCase
@@ -14,8 +15,9 @@ class LoginTest extends TestCase
     public function user_can_login_and_logout()
     {
         $user = factory(User::class)->create(['name' => 'Nama Member', 'email' => 'email@mail.com']);
+        app(ClientRepository::class)->createPersonalAccessClient(null, config('app.name'), config('app.url'));
 
-        $this->visit(route('login'));
+        $this->visitRoute('login');
 
         $this->submitForm(__('auth.login'), [
             'email' => 'email@mail.com',

--- a/tests/Feature/MasjidProfileTest.php
+++ b/tests/Feature/MasjidProfileTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use Facades\App\Helpers\Setting;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Passport\ClientRepository;
 use Tests\TestCase;
 
 class MasjidProfileTest extends TestCase
@@ -21,7 +22,14 @@ class MasjidProfileTest extends TestCase
     /** @test */
     public function admin_user_can_update_masjid_profile_data()
     {
-        $user = $this->loginAsUser();
+        $this->createUser('admin', ['name' => 'Nama Member', 'email' => 'email@mail.com']);
+        app(ClientRepository::class)->createPersonalAccessClient(null, config('app.name'), config('app.url'));
+
+        $this->visitRoute('login');
+        $this->submitForm(__('auth.login'), [
+            'email' => 'email@mail.com',
+            'password' => 'secret',
+        ]);
 
         $this->visitRoute('masjid_profile.edit');
 


### PR DESCRIPTION
## Deskripsi

Pada PR ini, kita ingin memberdayakan Laravel Passport sebagai API token untuk autentikasi pada endpoint API.

### Kasus

Pada implementasi saat ini, kita menggunakan `web` dan `auth` middlware untuk endpoint `POST /api/masjid_profile/image`. Autorisasinya menggunakan CSRF token yang dikirim pada payload request.

Kendalanya:
1. Saya belum tahu bagaimana cara ideal untuk membuat feature test untuk fitur tersebut
2. Ke depannya jika ada fitur upload logo masjid dari 3rd party app (misal aplikasi android), kita mesti bikin endpoint tersendiri.

### Solusi yang dicoba

1. Ubah middleware dari endpoint `POST /api/masjid_profile/image` dari `web` dan `auth` menjadi `auth:api` (laravel passport)
2. Setiap kali user login, generate personal access token, simpan di session
3. Ketika perlu request API ke endpoint tersebut, ambil token dari session.
4. Token expired 1 hari
5. Jika token tidak ditemukan di session, logout user dan wajib login kembali.

## Checklist

- [x] Tambah middlware untuk cek `session('auth.access_token')`
- [x] Jika access token hilang dari session, user ter-logout
- [x] Access token di-create ketika user berhasil login
- [x] Personal access token dibuat 1 hari saja

