### PR TITLE
Tampilkan Lampiran Nota / Bukti Transaksi pada Laporan Publik

### DIFF
--- a/app/Http/Controllers/BookController.php
+++ b/app/Http/Controllers/BookController.php
@@ -91,6 +91,7 @@ class BookController extends Controller
             'status_id' => ['required', Rule::in(Book::getConstants('STATUS'))],
             'bank_account_id' => 'nullable|exists:bank_accounts,id',
             'report_visibility_code' => ['required', Rule::in(Book::getConstants('REPORT_VISIBILITY'))],
+            'transaction_files_visibility_code' => ['required', Rule::in(Book::getConstants('REPORT_VISIBILITY'))],
             'budget' => ['nullable', 'numeric'],
             'report_periode_code' => ['required', Rule::in(Book::getConstants('REPORT_PERIODE'))],
             'income_partner_codes' => ['nullable', 'array'],
@@ -135,6 +136,7 @@ class BookController extends Controller
         array_key_exists('acknowledgment_text_right', $bookData) ? Setting::for($book)->set('acknowledgment_text_right', $bookData['acknowledgment_text_right']) : null;
         array_key_exists('sign_position_right', $bookData) ? Setting::for($book)->set('sign_position_right', $bookData['sign_position_right']) : null;
         array_key_exists('sign_name_right', $bookData) ? Setting::for($book)->set('sign_name_right', $bookData['sign_name_right']) : null;
+        array_key_exists('transaction_files_visibility_code', $bookData) ? Setting::for($book)->set('transaction_files_visibility_code', $bookData['transaction_files_visibility_code']) : null;
         Setting::for($book)->set('has_pdf_page_number', $bookData['has_pdf_page_number']);
         Setting::for($book)->set('income_partner_codes', json_encode(array_keys($bookData['income_partner_codes'] ?? [])));
         Setting::for($book)->set('income_partner_null', $bookData['income_partner_null']);

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -109,7 +109,7 @@ class Controller extends BaseController
             }
         });
 
-        return $transactionQuery->orderBy('date', 'asc')->with('category', 'book')->get();
+        return $transactionQuery->orderBy('date', 'asc')->with('category', 'book', 'files')->get();
     }
 
     protected function getIncomeTotal($transactions)

--- a/app/Http/Controllers/Reports/PublicFinanceController.php
+++ b/app/Http/Controllers/Reports/PublicFinanceController.php
@@ -67,10 +67,11 @@ class PublicFinanceController extends FinanceController
         $currentMonthEndDate = $endDate->clone();
 
         $reportPeriode = $book->report_periode_code;
+        $isTransactionFilesVisible = Setting::for($book)->get('transaction_files_visibility_code') == Book::REPORT_VISIBILITY_PUBLIC;
 
         return view('public_reports.finance.'.$reportPeriode.'.categorized', compact(
-            'startDate', 'endDate', 'currentMonthEndDate', 'reportPeriode',
-            'groupedTransactions', 'incomeCategories', 'spendingCategories'
+            'startDate', 'endDate', 'currentMonthEndDate', 'reportPeriode', 'groupedTransactions', 'incomeCategories',
+            'spendingCategories', 'isTransactionFilesVisible'
         ));
     }
 
@@ -89,9 +90,11 @@ class PublicFinanceController extends FinanceController
 
         $reportPeriode = $book->report_periode_code;
         $lastMonthDate = Carbon::parse($startDate)->subDay();
+        $isTransactionFilesVisible = Setting::for($book)->get('transaction_files_visibility_code') == Book::REPORT_VISIBILITY_PUBLIC;
 
         return view('public_reports.finance.'.$reportPeriode.'.detailed', compact(
-            'startDate', 'endDate', 'groupedTransactions', 'currentMonthEndDate', 'reportPeriode', 'lastMonthDate'
+            'startDate', 'endDate', 'groupedTransactions', 'currentMonthEndDate', 'reportPeriode', 'lastMonthDate',
+            'isTransactionFilesVisible'
         ));
     }
 

--- a/app/Http/Controllers/Transactions/FileController.php
+++ b/app/Http/Controllers/Transactions/FileController.php
@@ -16,7 +16,7 @@ class FileController extends Controller
 
         $payload = $request->validate([
             'files' => ['required', 'array'],
-            'files.*' => ['file', 'max:5120'],
+            'files.*' => ['file', 'mimes:jpg,bmp,png', 'max:5120'],
             'title' => ['nullable', 'max:255'],
             'description' => ['nullable', 'max:255'],
         ]);

--- a/app/Http/Livewire/Transactions/FilesIndicator.php
+++ b/app/Http/Livewire/Transactions/FilesIndicator.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Livewire\Transactions;
+
+use Livewire\Component;
+
+class FilesIndicator extends Component
+{
+    public $transaction;
+    public $files;
+
+    public function mount()
+    {
+        $this->files = $this->transaction->files;
+    }
+
+    public function render()
+    {
+        return view('livewire.transactions.files_indicator');
+    }
+}

--- a/app/Http/Requests/Transactions/CreateRequest.php
+++ b/app/Http/Requests/Transactions/CreateRequest.php
@@ -36,7 +36,7 @@ class CreateRequest extends FormRequest
             'book_id' => ['required', 'exists:books,id'],
             'bank_account_id' => ['nullable', 'exists:bank_accounts,id'],
             'files' => ['nullable', 'array'],
-            'files.*' => ['file', 'max:5120'],
+            'files.*' => ['file', 'mimes:jpg,bmp,png', 'max:5120'],
         ];
     }
 

--- a/resources/lang/en/book.php
+++ b/resources/lang/en/book.php
@@ -46,6 +46,7 @@ return [
     'report_visibility' => 'Report Visibility',
     'report_visibility_public' => 'Public',
     'report_visibility_internal' => 'Internal',
+    'transaction_files_visibility' => 'Transaction Files Visibility',
     'manager' => 'Finance User',
     'manager_info_text' => 'Finance user will have write access to this book.',
     'income_partners' => 'Income Partners',

--- a/resources/lang/id/book.php
+++ b/resources/lang/id/book.php
@@ -46,6 +46,7 @@ return [
     'report_visibility' => 'Visibilitas Laporan',
     'report_visibility_public' => 'Publik',
     'report_visibility_internal' => 'Internal',
+    'transaction_files_visibility' => 'Visibilitas File pada Transaksi',
     'manager' => 'Pengelola/Bendahara',
     'manager_info_text' => 'User bendahara dapat mengelola dan mengubah data buku kas / program kas ini.',
     'income_partners' => 'Partner utk Pemasukan',

--- a/resources/views/books/edit.blade.php
+++ b/resources/views/books/edit.blade.php
@@ -98,21 +98,28 @@
                         @else
                             {!! FormField::textDisplay(__('book.manager'), $book->manager->name) !!}
                         @endcan
+                        {!! FormField::radios('status_id', [
+                            App\Models\Book::STATUS_INACTIVE => __('book.status_inactive'),
+                            App\Models\Book::STATUS_ACTIVE => __('app.active')
+                        ], ['label' => __('app.status')]) !!}
                     </div>
                     <div class="col-md-6">
                         <h4 class="text-primary">{{ __('settings.settings') }}</h4>
                         <div class="row">
                             <div class="col-md-6">
-                                {!! FormField::radios('status_id', [
-                                    App\Models\Book::STATUS_INACTIVE => __('book.status_inactive'),
-                                    App\Models\Book::STATUS_ACTIVE => __('app.active')
-                                ], ['label' => __('app.status')]) !!}
+                                {!! FormField::radios('report_visibility_code', [
+                                    App\Models\Book::REPORT_VISIBILITY_PUBLIC => __('book.report_visibility_public'),
+                                    App\Models\Book::REPORT_VISIBILITY_INTERNAL => __('book.report_visibility_internal')
+                                ], ['label' => __('book.report_visibility')]) !!}
                             </div>
                             <div class="col-md-6">
-                                {!! FormField::radios('report_visibility_code', [
-                                    App\Models\Book::REPORT_VISIBILITY_PUBLIC => __('category.report_visibility_public'),
-                                    App\Models\Book::REPORT_VISIBILITY_INTERNAL => __('category.report_visibility_internal')
-                                ], ['label' => __('category.report_visibility')]) !!}
+                                {!! FormField::radios('transaction_files_visibility_code', [
+                                    App\Models\Book::REPORT_VISIBILITY_PUBLIC => __('book.report_visibility_public'),
+                                    App\Models\Book::REPORT_VISIBILITY_INTERNAL => __('book.report_visibility_internal')
+                                ], [
+                                    'value' => Setting::for($book)->get('transaction_files_visibility_code', App\Models\Book::REPORT_VISIBILITY_INTERNAL),
+                                    'label' => __('book.transaction_files_visibility'),
+                                ]) !!}
                             </div>
                         </div>
                         <div class="row">

--- a/resources/views/books/show.blade.php
+++ b/resources/views/books/show.blade.php
@@ -49,7 +49,7 @@
             </table>
             <div class="card-footer">
                 @can('update', $book)
-                    {{ link_to_route('books.edit', __('book.edit'), [$book], ['class' => 'btn btn-warning', 'id' => 'edit-book-'.$book->id]) }}
+                    {{ link_to_route('books.edit', __('book.edit'), [$book], ['class' => 'btn btn-warning text-dark', 'id' => 'edit-book-'.$book->id]) }}
                 @endcan
                 {{ link_to_route('books.index', __('book.back_to_index'), [], ['class' => 'btn btn-link']) }}
             </div>

--- a/resources/views/books/show.blade.php
+++ b/resources/views/books/show.blade.php
@@ -28,7 +28,6 @@
                     <tr><td>{{ __('bank_account.bank_account') }}</td><td>{{ $book->bankAccount->name }}</td></tr>
                     <tr><td>{{ __('book.budget') }}</td><td>{{ format_number($book->budget ?: 0) }}</td></tr>
                     <tr><td>{{ __('app.status') }}</td><td>{{ $book->status }}</td></tr>
-                    <tr><td>{{ __('book.report_visibility') }}</td><td>{{ __('book.report_visibility_'.$book->report_visibility_code) }}</td></tr>
                     <tr><td>{{ __('report.periode') }}</td><td>{{ __('report.'.$book->report_periode_code) }}</td></tr>
                     <tr><td>{{ __('report.start_week_day') }}</td><td>{{ __('time.days.'.$book->start_week_day_code) }}</td></tr>
                     <tr><td>{{ __('report.has_pdf_page_number') }}</td><td>{{ $book->start_week_day_code == '0' ? __('app.no') : __('app.yes') }}</td></tr>
@@ -61,6 +60,21 @@
             <div class="card-header">{{ __('report.finance_summary') }}</div>
             <div class="page-options d-flex"></div>
             @livewire('books.financial-summary', ['bookId' => $book->id])
+        </div>
+        <div class="card">
+            <div class="card-header">{{ __('book.visibility') }}</div>
+            <table class="table table-sm card-table">
+                <tbody>
+                    <tr>
+                        <td class="col-7">{{ __('book.report_visibility') }}</td>
+                        <td>{{ __('book.report_visibility_'.$book->report_visibility_code) }}</td>
+                    </tr>
+                    <tr>
+                        <td>{{ __('book.transaction_files_visibility') }}</td>
+                        <td>{{ __('book.report_visibility_'.Setting::for($book)->get('transaction_files_visibility_code', App\Models\Book::REPORT_VISIBILITY_INTERNAL)) }}</td>
+                    </tr>
+                </tbody>
+            </table>
         </div>
         <div class="card">
             <div class="card-header">{{ __('report.signatures') }}</div>

--- a/resources/views/livewire/transactions/files_indicator.blade.php
+++ b/resources/views/livewire/transactions/files_indicator.blade.php
@@ -1,12 +1,12 @@
-<span class="badge badge-light" style="font-size: 90%;">
+<span style="font-size: 90%;">
 @if ($files->count())
     @if ($files->count() == 1)
-        <a href="{{ asset('storage/'.$files->first()->file_path) }}" class="text-dark">
+        <a href="{{ asset('storage/'.$files->first()->file_path) }}" class="badge badge-light text-dark">
             1 <i class="fe fe-image"></i>
         </a>
     @else
         <div class="dropdown">
-            <a class="text-dark" data-toggle="dropdown" aria-expanded="false" style="cursor:pointer">
+            <a class="badge badge-light text-dark" data-toggle="dropdown" aria-expanded="false" style="cursor:pointer">
                 {{ $files->count() }} <i class="fe fe-image"></i>
             </a>
             <div class="dropdown-menu">

--- a/resources/views/livewire/transactions/files_indicator.blade.php
+++ b/resources/views/livewire/transactions/files_indicator.blade.php
@@ -1,0 +1,28 @@
+<span class="badge badge-light" style="font-size: 90%;">
+@if ($files->count())
+    @if ($files->count() == 1)
+        <a href="{{ asset('storage/'.$files->first()->file_path) }}" class="text-dark">
+            1 <i class="fe fe-image"></i>
+        </a>
+    @else
+        <div class="dropdown">
+            <a class="text-dark" data-toggle="dropdown" aria-expanded="false" style="cursor:pointer">
+                {{ $files->count() }} <i class="fe fe-image"></i>
+            </a>
+            <div class="dropdown-menu">
+                @foreach ($files as $key => $file)
+                    <div class="dropdown-item">
+                        <a href="{{ asset('storage/'.$file->file_path) }}">
+                            @if ($file->title)
+                                <div>{{ $file->title }}</div>
+                            @else
+                                <div>{{ __('transaction.files') }} {{ 1 + $key }}</div>
+                            @endif
+                        </a>
+                    </div>
+                @endforeach
+            </div>
+        </div>
+    @endif
+@endif
+</span>

--- a/resources/views/public_reports/finance/_public_content_categorized.blade.php
+++ b/resources/views/public_reports/finance/_public_content_categorized.blade.php
@@ -19,9 +19,11 @@
                 <td class="text-center col-1">{{ ++$key }}</td>
                 <td class="text-center col-2">{{ $transaction->date }}</td>
                 <td class="col-4">
-                    <span class="float-right">
-                        @livewire('transactions.files-indicator', ['transaction' => $transaction])
-                    </span>
+                    @if ($isTransactionFilesVisible)
+                        <span class="float-right">
+                            @livewire('transactions.files-indicator', ['transaction' => $transaction])
+                        </span>
+                    @endif
                     {!! $transaction->date_alert !!} {{ $transaction->description }}
                 </td>
                 <td class="text-right col-3">{{ format_number($transaction->amount) }}</td>

--- a/resources/views/public_reports/finance/_public_content_categorized.blade.php
+++ b/resources/views/public_reports/finance/_public_content_categorized.blade.php
@@ -18,7 +18,12 @@
             <tr>
                 <td class="text-center col-1">{{ ++$key }}</td>
                 <td class="text-center col-2">{{ $transaction->date }}</td>
-                <td class="col-4">{!! $transaction->date_alert !!} {{ $transaction->description }}</td>
+                <td class="col-4">
+                    <span class="float-right">
+                        @livewire('transactions.files-indicator', ['transaction' => $transaction])
+                    </span>
+                    {!! $transaction->date_alert !!} {{ $transaction->description }}
+                </td>
                 <td class="text-right col-3">{{ format_number($transaction->amount) }}</td>
             </tr>
             @endforeach

--- a/resources/views/public_reports/finance/_public_content_detailed.blade.php
+++ b/resources/views/public_reports/finance/_public_content_detailed.blade.php
@@ -49,9 +49,11 @@
                         <tr class="{{ $transaction->is_strong ? 'strong' : '' }}">
                             <td class="text-center">{{ $transaction->date }}</td>
                             <td {{ $transaction->is_strong ? 'style=text-decoration:underline' : '' }}>
-                                <span class="float-right">
-                                    @livewire('transactions.files-indicator', ['transaction' => $transaction])
-                                </span>
+                                @if ($isTransactionFilesVisible)
+                                    <span class="float-right">
+                                        @livewire('transactions.files-indicator', ['transaction' => $transaction])
+                                    </span>
+                                @endif
                                 {!! $transaction->date_alert !!} {{ $transaction->description }}
                             </td>
                             <td class="text-right text-nowrap">{{ $transaction->in_out ? format_number($transaction->amount) : '' }}</td>

--- a/resources/views/public_reports/finance/_public_content_detailed.blade.php
+++ b/resources/views/public_reports/finance/_public_content_detailed.blade.php
@@ -49,32 +49,9 @@
                         <tr class="{{ $transaction->is_strong ? 'strong' : '' }}">
                             <td class="text-center">{{ $transaction->date }}</td>
                             <td {{ $transaction->is_strong ? 'style=text-decoration:underline' : '' }}>
-                                @if ($transaction->files->count())
-                                    @if ($transaction->files->count() == 1)
-                                        <a href="{{ asset('storage/'.$transaction->files->first()->file_path) }}" class="badge badge-light text-dark float-right">
-                                            1 <i class="fe fe-image"></i>
-                                        </a>
-                                    @else
-                                        <div class="dropdown float-right">
-                                            <a class="badge badge-light text-dark" data-toggle="dropdown" aria-expanded="false" style="cursor:pointer">
-                                                {{ $transaction->files->count() }} <i class="fe fe-image"></i>
-                                            </a>
-                                            <div class="dropdown-menu">
-                                                @foreach ($transaction->files as $key => $file)
-                                                    <div class="dropdown-item">
-                                                        <a href="{{ asset('storage/'.$file->file_path) }}">
-                                                            @if ($file->title)
-                                                                <div>{{ $file->title }}</div>
-                                                            @else
-                                                                <div>{{ __('transaction.files') }} {{ 1 + $key }}</div>
-                                                            @endif
-                                                        </a>
-                                                    </div>
-                                                @endforeach
-                                            </div>
-                                        </div>
-                                    @endif
-                                @endif
+                                <span class="float-right">
+                                    @livewire('transactions.files-indicator', ['transaction' => $transaction])
+                                </span>
                                 {!! $transaction->date_alert !!} {{ $transaction->description }}
                             </td>
                             <td class="text-right text-nowrap">{{ $transaction->in_out ? format_number($transaction->amount) : '' }}</td>

--- a/resources/views/public_reports/finance/_public_content_detailed.blade.php
+++ b/resources/views/public_reports/finance/_public_content_detailed.blade.php
@@ -49,6 +49,26 @@
                         <tr class="{{ $transaction->is_strong ? 'strong' : '' }}">
                             <td class="text-center">{{ $transaction->date }}</td>
                             <td {{ $transaction->is_strong ? 'style=text-decoration:underline' : '' }}>
+                                @if ($transaction->files->count())
+                                    <div class="dropdown float-right">
+                                        <a class="badge badge-light text-dark" data-toggle="dropdown" aria-expanded="false" style="cursor:pointer">
+                                            {{ $transaction->files->count() }} <i class="fe fe-image"></i>
+                                        </a>
+                                        <div class="dropdown-menu">
+                                            @foreach ($transaction->files as $key => $file)
+                                                <div class="dropdown-item">
+                                                    <a href="{{ asset('storage/'.$file->file_path) }}">
+                                                        @if ($file->title)
+                                                            <div>{{ $file->title }}</div>
+                                                        @else
+                                                            <div>{{ __('transaction.files') }} {{ 1 + $key }}</div>
+                                                        @endif
+                                                    </a>
+                                                </div>
+                                            @endforeach
+                                        </div>
+                                    </div>
+                                @endif
                                 {!! $transaction->date_alert !!} {{ $transaction->description }}
                             </td>
                             <td class="text-right text-nowrap">{{ $transaction->in_out ? format_number($transaction->amount) : '' }}</td>

--- a/resources/views/public_reports/finance/_public_content_detailed.blade.php
+++ b/resources/views/public_reports/finance/_public_content_detailed.blade.php
@@ -50,24 +50,30 @@
                             <td class="text-center">{{ $transaction->date }}</td>
                             <td {{ $transaction->is_strong ? 'style=text-decoration:underline' : '' }}>
                                 @if ($transaction->files->count())
-                                    <div class="dropdown float-right">
-                                        <a class="badge badge-light text-dark" data-toggle="dropdown" aria-expanded="false" style="cursor:pointer">
-                                            {{ $transaction->files->count() }} <i class="fe fe-image"></i>
+                                    @if ($transaction->files->count() == 1)
+                                        <a href="{{ asset('storage/'.$transaction->files->first()->file_path) }}" class="badge badge-light text-dark float-right">
+                                            1 <i class="fe fe-image"></i>
                                         </a>
-                                        <div class="dropdown-menu">
-                                            @foreach ($transaction->files as $key => $file)
-                                                <div class="dropdown-item">
-                                                    <a href="{{ asset('storage/'.$file->file_path) }}">
-                                                        @if ($file->title)
-                                                            <div>{{ $file->title }}</div>
-                                                        @else
-                                                            <div>{{ __('transaction.files') }} {{ 1 + $key }}</div>
-                                                        @endif
-                                                    </a>
-                                                </div>
-                                            @endforeach
+                                    @else
+                                        <div class="dropdown float-right">
+                                            <a class="badge badge-light text-dark" data-toggle="dropdown" aria-expanded="false" style="cursor:pointer">
+                                                {{ $transaction->files->count() }} <i class="fe fe-image"></i>
+                                            </a>
+                                            <div class="dropdown-menu">
+                                                @foreach ($transaction->files as $key => $file)
+                                                    <div class="dropdown-item">
+                                                        <a href="{{ asset('storage/'.$file->file_path) }}">
+                                                            @if ($file->title)
+                                                                <div>{{ $file->title }}</div>
+                                                            @else
+                                                                <div>{{ __('transaction.files') }} {{ 1 + $key }}</div>
+                                                            @endif
+                                                        </a>
+                                                    </div>
+                                                @endforeach
+                                            </div>
                                         </div>
-                                    </div>
+                                    @endif
                                 @endif
                                 {!! $transaction->date_alert !!} {{ $transaction->description }}
                             </td>

--- a/tests/Feature/Books/ManageBookTest.php
+++ b/tests/Feature/Books/ManageBookTest.php
@@ -102,6 +102,7 @@ class ManageBookTest extends TestCase
             'bank_account_id' => $bankAccount->id,
             'manager_id' => $financeUser->id,
             'report_visibility_code' => Book::REPORT_VISIBILITY_PUBLIC,
+            'transaction_files_visibility_code' => Book::REPORT_VISIBILITY_PUBLIC,
             'budget' => 1000000,
             'report_periode_code' => Book::REPORT_PERIODE_IN_WEEKS,
             'has_pdf_page_number' => 0,
@@ -141,6 +142,13 @@ class ManageBookTest extends TestCase
             'model_id' => $book->id,
             'key' => 'has_pdf_page_number',
             'value' => '0',
+        ]);
+
+        $this->seeInDatabase('settings', [
+            'model_type' => 'books',
+            'model_id' => $book->id,
+            'key' => 'transaction_files_visibility_code',
+            'value' => Book::REPORT_VISIBILITY_PUBLIC,
         ]);
 
         $this->seeInDatabase('settings', [
@@ -257,6 +265,11 @@ class ManageBookTest extends TestCase
         $this->click('edit-book-'.$book->id);
         $this->seeRouteIs('books.edit', [$book]);
         $this->seeElement('input', ['id' => 'sign_name_right', 'value' => 'H. Dedy']);
+        $this->seeElement('input', [
+            'id' => 'transaction_files_visibility_code_'.Book::REPORT_VISIBILITY_INTERNAL,
+            'type' => 'radio',
+            'checked' => 'checked',
+        ]);
 
         $this->submitForm(__('book.update'), [
             'name' => 'Book 1 name',
@@ -265,6 +278,7 @@ class ManageBookTest extends TestCase
             'bank_account_id' => $bankAccount->id,
             'manager_id' => $financeUser->id,
             'report_visibility_code' => Book::REPORT_VISIBILITY_PUBLIC,
+            'transaction_files_visibility_code' => Book::REPORT_VISIBILITY_PUBLIC,
             'budget' => 1000000,
             'report_periode_code' => Book::REPORT_PERIODE_IN_WEEKS,
             'has_pdf_page_number' => 0,


### PR DESCRIPTION
### Deskripsi

Pada PR ini, kita melakukan beberapa improvement pada fitur lampiran gambar/foto yang diupload pada setiap transaksi agar tampil pada laporan publik per buku kas. Improvement ini berdasarkan masukan dari beberapa anggota grup telegram komunitas: https://t.me/bukumasjid_id.

### Task Link

- Tidak ada

### Checklist

- [x] Validasi file upload agar hanya dapat menerima file berupa gambar saja (JPG, PNG, BMP)
- [x] Menampilkan icon/indikator file untuk transaksi yang ada gambarnya pada laporan publik
- [x] Jika hanya 1 file, maka icon berupa link menuju ke file gambar
- [x] Jika lebih dari 1 file, maka icon berupa dropdown untuk menampilkan list judul gambar, Klik pada judul untuk melihat gambar
- [x] Pengaturan pada buku kas, untuk visibilitas file transaksi (seluruh buku): Internal (default) atau Publik
- [x] Jika pengaturan visibilitas file transaksi internal, maka indikator file **tidak tampil** di laporan publik
- [x] Jika pengaturan visibilitas file transaksi publik, maka indikator file **tampil** di laporan publik


### Screenshot

Validasi file upload

![screen_2025-01-16_011](https://github.com/user-attachments/assets/fbc4a67e-96cb-4922-ad71-3a08c8c7ab93)

Icon/indikator file pada laporan publik

![screen_2025-01-16_010](https://github.com/user-attachments/assets/42ba4f2e-4de9-4264-816d-503bdb540c5e)

Pengaturan visibilitas file transaksi per buku kas

![screen_2025-01-18_001](https://github.com/user-attachments/assets/24811db1-a86f-4957-b4e8-37761ec01304)
