### PR TITLE
Perbaikan Kategori dan Jenis pada Edit Transaksi

### DIFF
--- a/app/Http/Controllers/Api/CategoriesController.php
+++ b/app/Http/Controllers/Api/CategoriesController.php
@@ -7,6 +7,7 @@ use App\Http\Requests\Categories\CreateRequest;
 use App\Http\Requests\Categories\DeleteRequest;
 use App\Http\Requests\Categories\UpdateRequest;
 use App\Models\Category;
+use Illuminate\Http\Request;
 
 class CategoriesController extends Controller
 {
@@ -20,6 +21,31 @@ class CategoriesController extends Controller
         $categories = Category::all();
 
         return $categories;
+    }
+
+    /**
+     * Get categories based on transaction type (income/spending).
+     *
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function getTransactionCategories(Request $request)
+    {
+        $request->validate([
+            'in_out' => 'required|in:0,1',
+            'book_id' => 'required|exists:books,id',
+        ]);
+
+        $categoryColor = $request->in_out ? config('masjid.income_color') : config('masjid.spending_color');
+        
+        $categories = Category::where('status_id', Category::STATUS_ACTIVE)
+            ->where('book_id', $request->book_id)
+            ->where('color', $categoryColor)
+            ->orderBy('name')
+            ->get(['id', 'name', 'color']);
+
+        return response()->json([
+            'data' => $categories,
+        ]);
     }
 
     /**

--- a/app/Http/Controllers/Api/CategoriesController.php
+++ b/app/Http/Controllers/Api/CategoriesController.php
@@ -36,7 +36,7 @@ class CategoriesController extends Controller
         ]);
 
         $categoryColor = $request->in_out ? config('masjid.income_color') : config('masjid.spending_color');
-        
+
         $categories = Category::where('status_id', Category::STATUS_ACTIVE)
             ->where('book_id', $request->book_id)
             ->where('color', $categoryColor)

--- a/app/Http/Controllers/TransactionsController.php
+++ b/app/Http/Controllers/TransactionsController.php
@@ -173,7 +173,12 @@ class TransactionsController extends Controller
         $this->authorize('manage-transactions', $transaction->book);
         $this->authorize('update', $transaction);
 
-        $categories = $this->getCategoryList();
+        $categoryColor = $transaction->in_out ? config('masjid.income_color') : config('masjid.spending_color');
+        $categories = Category::where('status_id', Category::STATUS_ACTIVE)
+            ->where('color', $categoryColor)
+            ->orderBy('name')
+            ->pluck('name', 'id');
+
         $bankAccounts = BankAccount::where('is_active', BankAccount::STATUS_ACTIVE)->pluck('name', 'id');
         $partnerTypes = (new Partner)->getAvailableTypes();
         $partnerDefaultValue = __('partner.partner');

--- a/app/Http/Requests/Transactions/UpdateRequest.php
+++ b/app/Http/Requests/Transactions/UpdateRequest.php
@@ -41,7 +41,7 @@ class UpdateRequest extends FormRequest
                                 $transactionType = $inOut ? __('transaction.income') : __('transaction.spending');
                                 $fail(__('validation.category_type_mismatch', [
                                     'category' => $category->name,
-                                    'type' => $transactionType
+                                    'type' => $transactionType,
                                 ]));
                             }
                         }

--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -128,6 +128,8 @@ return [
         ],
     ],
 
+    'category_type_mismatch' => 'Category ":category" does not match with :type transaction type.',
+
     /*
     |--------------------------------------------------------------------------
     | Custom Validation Attributes

--- a/resources/lang/id/validation.php
+++ b/resources/lang/id/validation.php
@@ -128,6 +128,8 @@ return [
         ],
     ],
 
+    'category_type_mismatch' => 'Kategori ":category" tidak sesuai dengan jenis transaksi :type.',
+
     /*
     |---------------------------------------------------------------------------------------
     | Kustom Validasi Atribut

--- a/routes/api.php
+++ b/routes/api.php
@@ -12,6 +12,9 @@
 */
 
 // Public Routes
+
+use Illuminate\Support\Facades\Route;
+
 Route::get('schedules', 'Api\PublicScheduleController@index')->name('api.schedules.index');
 Route::get('masjid_profile', [App\Http\Controllers\Api\MasjidProfileController::class, 'show'])->name('api.masjid_profile.show');
 
@@ -62,6 +65,11 @@ Route::group(['middleware' => ['auth', 'web'], 'as' => 'api.'], function () {
 
     Route::post('books/{book}/upload_poster_image', [App\Http\Controllers\Api\BookController::class, 'updatePosterImage'])->name('books.upload_poster_image');
     Route::post('books/{book}/upload_thumbnail_image', [App\Http\Controllers\Api\BookController::class, 'updateThumbnailImage'])->name('books.upload_thumbnail_image');
+
+    /*
+     * Transaction Categories Endpoint for AJAX
+     */
+    Route::get('transaction_categories', [App\Http\Controllers\Api\CategoriesController::class, 'getTransactionCategories'])->name('transaction_categories');
 });
 
 if (config('features.shalat_time.is_active')) {

--- a/tests/Feature/Api/TransactionCategoriesTest.php
+++ b/tests/Feature/Api/TransactionCategoriesTest.php
@@ -1,0 +1,292 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\Book;
+use App\Models\Category;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Passport\Passport;
+use Tests\TestCase;
+
+class TransactionCategoriesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function it_returns_income_categories_for_income_transaction_type()
+    {
+        $user = $this->loginAsUser();
+        $book = factory(Book::class)->create(['creator_id' => $user->id]);
+        
+        // incomeCategory1
+        factory(Category::class)->create([
+            'name' => 'Donasi Masjid',
+            'color' => config('masjid.income_color'),
+            'book_id' => $book->id,
+            'creator_id' => $user->id,
+        ]);
+
+        // incomeCategory2
+        factory(Category::class)->create([
+            'name' => 'Infaq Jumat',
+            'color' => config('masjid.income_color'),
+            'book_id' => $book->id,
+            'creator_id' => $user->id,
+        ]);
+        
+        factory(Category::class)->create([
+            'name' => 'Biaya Listrik',
+            'color' => config('masjid.spending_color'),
+            'book_id' => $book->id,
+            'creator_id' => $user->id,
+        ]);
+
+        $this->get(route('api.transaction_categories', [
+            'in_out' => 1, // Income
+            'book_id' => $book->id,
+        ]));
+
+        $this->assertResponseOk();
+        $this->seeJsonStructure([
+            'data' => [
+                '*' => ['id', 'name', 'color']
+            ]
+        ]);
+
+        $this->seeJson(['name' => 'Donasi Masjid']);
+        $this->seeJson(['name' => 'Infaq Jumat']);
+        $this->seeJson(['color' => config('masjid.income_color')]);
+        
+        $this->dontSeeJson(['name' => 'Biaya Listrik']);
+    }
+
+    /** @test */
+    public function it_returns_spending_categories_for_spending_transaction_type()
+    {
+        $user = $this->loginAsUser();
+        $book = factory(Book::class)->create(['creator_id' => $user->id]);
+        
+        // spendingCategory1
+        factory(Category::class)->create([
+            'name' => 'Biaya Listrik',
+            'color' => config('masjid.spending_color'),
+            'book_id' => $book->id,
+            'creator_id' => $user->id,
+        ]);
+        // spendingCategory2
+        factory(Category::class)->create([
+            'name' => 'Biaya Air',
+            'color' => config('masjid.spending_color'),
+            'book_id' => $book->id,
+            'creator_id' => $user->id,
+        ]);
+        
+        factory(Category::class)->create([
+            'name' => 'Donasi Masjid',
+            'color' => config('masjid.income_color'),
+            'book_id' => $book->id,
+            'creator_id' => $user->id,
+        ]);
+
+        $this->get(route('api.transaction_categories', [
+            'in_out' => 0, // Spending
+            'book_id' => $book->id,
+        ]));
+
+        $this->assertResponseOk();
+        $this->seeJsonStructure([
+            'data' => [
+                '*' => ['id', 'name', 'color']
+            ]
+        ]);
+
+        $this->seeJson(['name' => 'Biaya Listrik']);
+        $this->seeJson(['name' => 'Biaya Air']);
+        $this->seeJson(['color' => config('masjid.spending_color')]);
+        
+        $this->dontSeeJson(['name' => 'Donasi Masjid']);
+    }
+
+    /** @test */
+    public function it_returns_empty_array_when_no_categories_exist_for_transaction_type()
+    {
+        $user = $this->loginAsUser();
+        $book = factory(Book::class)->create(['creator_id' => $user->id]);
+        
+        factory(Category::class)->create([
+            'name' => 'Donasi Masjid',
+            'color' => config('masjid.income_color'),
+            'book_id' => $book->id,
+            'creator_id' => $user->id,
+        ]);
+
+        $this->get(route('api.transaction_categories', [
+            'in_out' => 0,
+            'book_id' => $book->id,
+        ]));
+
+        $this->assertResponseOk();
+        $this->seeJson(['data' => []]);
+    }
+
+    /** @test */
+    public function it_returns_empty_array_when_no_categories_exist_for_book()
+    {
+        $user = $this->loginAsUser();
+        $book = factory(Book::class)->create(['creator_id' => $user->id]);
+        $otherBook = factory(Book::class)->create();
+        
+        factory(Category::class)->create([
+            'name' => 'Other Book Category',
+            'color' => config('masjid.income_color'),
+            'book_id' => $otherBook->id,
+            'creator_id' => $user->id,
+        ]);
+
+        $this->get(route('api.transaction_categories', [
+            'in_out' => 1, // Income
+            'book_id' => $book->id,
+        ]));
+
+        $this->assertResponseOk();
+        $this->seeJson(['data' => []]);
+    }
+
+    /** @test */
+    public function it_validates_required_in_out_parameter()
+    {
+        $user = $this->createUser();
+        Passport::actingAs($user);
+        $book = factory(Book::class)->create(['creator_id' => $user->id]);
+
+        $this->get(route('api.transaction_categories', [
+            'book_id' => $book->id,
+            // Missing in_out
+        ]), [
+            'Accept' => 'application/json',
+        ]);
+
+        $this->assertResponseStatus(422);
+    }
+
+    /** @test */
+    public function it_validates_in_out_parameter_values()
+    {
+        $user = $this->createUser();
+        Passport::actingAs($user);
+        $book = factory(Book::class)->create(['creator_id' => $user->id]);
+
+        $this->get(route('api.transaction_categories', [
+            'in_out' => 2, // Invalid, 0 or 1
+            'book_id' => $book->id,
+        ]), [
+            'Accept' => 'application/json',
+        ]);
+
+        $this->assertResponseStatus(422);
+    }
+
+    /** @test */
+    public function it_validates_required_book_id_parameter()
+    {
+        $user = $this->createUser();
+        Passport::actingAs($user);
+
+        $this->get(route('api.transaction_categories', [
+            'in_out' => 1,
+            // Missing book_id
+        ]), [
+            'Accept' => 'application/json',
+        ]);
+
+        $this->assertResponseStatus(422);
+    }
+
+    /** @test */
+    public function it_validates_book_id_exists_in_database()
+    {
+        $user = $this->createUser();
+        Passport::actingAs($user);
+
+        $this->get(route('api.transaction_categories', [
+            'in_out' => 1,
+            'book_id' => 99999,
+        ]), [
+            'Accept' => 'application/json',
+        ]);
+
+        $this->assertResponseStatus(422);
+    }
+
+    /** @test */
+    public function it_only_returns_active_categories()
+    {
+        $user = $this->loginAsUser();
+        $book = factory(Book::class)->create(['creator_id' => $user->id]);
+        
+        // activeCategoryy
+        factory(Category::class)->create([
+            'name' => 'Active Income Category',
+            'color' => config('masjid.income_color'),
+            'book_id' => $book->id,
+            'creator_id' => $user->id,
+            'status_id' => Category::STATUS_ACTIVE,
+        ]);
+        
+        // inactiveCategory
+        factory(Category::class)->create([
+            'name' => 'Inactive Income Category',
+            'color' => config('masjid.income_color'),
+            'book_id' => $book->id,
+            'creator_id' => $user->id,
+            'status_id' => Category::STATUS_INACTIVE,
+        ]);
+
+        $this->get(route('api.transaction_categories', [
+            'in_out' => 1,
+            'book_id' => $book->id,
+        ]));
+
+        $this->assertResponseOk();
+        
+        $this->seeJson(['name' => 'Active Income Category']);
+        $this->dontSeeJson(['name' => 'Inactive Income Category']);
+    }
+
+    /** @test */
+    public function it_returns_categories_sorted_by_name()
+    {
+        $user = $this->loginAsUser();
+        $book = factory(Book::class)->create(['creator_id' => $user->id]);
+        
+        factory(Category::class)->create([
+            'name' => 'Zakat',
+            'color' => config('masjid.income_color'),
+            'book_id' => $book->id,
+            'creator_id' => $user->id,
+        ]);
+        factory(Category::class)->create([
+            'name' => 'Donasi',
+            'color' => config('masjid.income_color'),
+            'book_id' => $book->id,
+            'creator_id' => $user->id,
+        ]);
+        factory(Category::class)->create([
+            'name' => 'Infaq',
+            'color' => config('masjid.income_color'),
+            'book_id' => $book->id,
+            'creator_id' => $user->id,
+        ]);
+
+        $this->get(route('api.transaction_categories', [
+            'in_out' => 1, // Income
+            'book_id' => $book->id,
+        ]));
+
+        $this->assertResponseOk();
+        
+        $this->seeJson(['name' => 'Donasi']);
+        $this->seeJson(['name' => 'Infaq']);
+        $this->seeJson(['name' => 'Zakat']);
+    }
+}

--- a/tests/Feature/Api/TransactionCategoriesTest.php
+++ b/tests/Feature/Api/TransactionCategoriesTest.php
@@ -17,7 +17,7 @@ class TransactionCategoriesTest extends TestCase
     {
         $user = $this->loginAsUser();
         $book = factory(Book::class)->create(['creator_id' => $user->id]);
-        
+
         // incomeCategory1
         factory(Category::class)->create([
             'name' => 'Donasi Masjid',
@@ -33,7 +33,7 @@ class TransactionCategoriesTest extends TestCase
             'book_id' => $book->id,
             'creator_id' => $user->id,
         ]);
-        
+
         factory(Category::class)->create([
             'name' => 'Biaya Listrik',
             'color' => config('masjid.spending_color'),
@@ -49,14 +49,14 @@ class TransactionCategoriesTest extends TestCase
         $this->assertResponseOk();
         $this->seeJsonStructure([
             'data' => [
-                '*' => ['id', 'name', 'color']
-            ]
+                '*' => ['id', 'name', 'color'],
+            ],
         ]);
 
         $this->seeJson(['name' => 'Donasi Masjid']);
         $this->seeJson(['name' => 'Infaq Jumat']);
         $this->seeJson(['color' => config('masjid.income_color')]);
-        
+
         $this->dontSeeJson(['name' => 'Biaya Listrik']);
     }
 
@@ -65,7 +65,7 @@ class TransactionCategoriesTest extends TestCase
     {
         $user = $this->loginAsUser();
         $book = factory(Book::class)->create(['creator_id' => $user->id]);
-        
+
         // spendingCategory1
         factory(Category::class)->create([
             'name' => 'Biaya Listrik',
@@ -80,7 +80,7 @@ class TransactionCategoriesTest extends TestCase
             'book_id' => $book->id,
             'creator_id' => $user->id,
         ]);
-        
+
         factory(Category::class)->create([
             'name' => 'Donasi Masjid',
             'color' => config('masjid.income_color'),
@@ -96,14 +96,14 @@ class TransactionCategoriesTest extends TestCase
         $this->assertResponseOk();
         $this->seeJsonStructure([
             'data' => [
-                '*' => ['id', 'name', 'color']
-            ]
+                '*' => ['id', 'name', 'color'],
+            ],
         ]);
 
         $this->seeJson(['name' => 'Biaya Listrik']);
         $this->seeJson(['name' => 'Biaya Air']);
         $this->seeJson(['color' => config('masjid.spending_color')]);
-        
+
         $this->dontSeeJson(['name' => 'Donasi Masjid']);
     }
 
@@ -112,7 +112,7 @@ class TransactionCategoriesTest extends TestCase
     {
         $user = $this->loginAsUser();
         $book = factory(Book::class)->create(['creator_id' => $user->id]);
-        
+
         factory(Category::class)->create([
             'name' => 'Donasi Masjid',
             'color' => config('masjid.income_color'),
@@ -135,7 +135,7 @@ class TransactionCategoriesTest extends TestCase
         $user = $this->loginAsUser();
         $book = factory(Book::class)->create(['creator_id' => $user->id]);
         $otherBook = factory(Book::class)->create();
-        
+
         factory(Category::class)->create([
             'name' => 'Other Book Category',
             'color' => config('masjid.income_color'),
@@ -223,7 +223,7 @@ class TransactionCategoriesTest extends TestCase
     {
         $user = $this->loginAsUser();
         $book = factory(Book::class)->create(['creator_id' => $user->id]);
-        
+
         // activeCategoryy
         factory(Category::class)->create([
             'name' => 'Active Income Category',
@@ -232,7 +232,7 @@ class TransactionCategoriesTest extends TestCase
             'creator_id' => $user->id,
             'status_id' => Category::STATUS_ACTIVE,
         ]);
-        
+
         // inactiveCategory
         factory(Category::class)->create([
             'name' => 'Inactive Income Category',
@@ -248,7 +248,7 @@ class TransactionCategoriesTest extends TestCase
         ]));
 
         $this->assertResponseOk();
-        
+
         $this->seeJson(['name' => 'Active Income Category']);
         $this->dontSeeJson(['name' => 'Inactive Income Category']);
     }
@@ -258,7 +258,7 @@ class TransactionCategoriesTest extends TestCase
     {
         $user = $this->loginAsUser();
         $book = factory(Book::class)->create(['creator_id' => $user->id]);
-        
+
         factory(Category::class)->create([
             'name' => 'Zakat',
             'color' => config('masjid.income_color'),
@@ -284,7 +284,7 @@ class TransactionCategoriesTest extends TestCase
         ]));
 
         $this->assertResponseOk();
-        
+
         $this->seeJson(['name' => 'Donasi']);
         $this->seeJson(['name' => 'Infaq']);
         $this->seeJson(['name' => 'Zakat']);


### PR DESCRIPTION
### Deskripsi
Bismillah, halo Mas @nafiesl. Izin memberikan perbaikan pada issue terkait. Update-nya sudah mengikuti Checklist yang diberikan.

### Task Link

 * close [Kategori pada saat Edit Transaksi tidak terfilter sesuai transaksi pengeluaran atau pemasukkan #136](https://github.com/buku-masjid/buku-masjid/issues/136)

### Checklist
- [x]  Buat endpoint API `/api/transaction_categories` untuk return list kategori berdasarkan jenis transaksi (pemasukan/pengeluaran)
- [x]  Buat automated testing untuk endpoint API `/api/transaction_categories`
    - [x]  Kirim payload jenis transaksi dan id buku kas, respons list kategori yang ada
    - [x]  Kirim payload jenis transaksi dan id buku kas, respons tidak ada kategori
    - [x]  Validasi payload wajib: `in_out:0,1`, `book_id:books.id`
- [x]  Buat query ajax call pada halaman edit transaksi, untuk mengisi dropdown kategori sesuai respons dari endpoint API.

### Screenshoot
Saat Jenis diganti, Kategori akan direset, lalu proses fetching data
<img width="1240" height="697" alt="image" src="https://github.com/user-attachments/assets/e3591441-a239-4be2-a7f5-855f65ba528e" />

Data Kategori akan berubah sesuai dengan Jenis nya
<img width="1222" height="698" alt="image" src="https://github.com/user-attachments/assets/c635f8e5-ce76-41bc-bc44-c62b9e3fc239" />

### Catatan
- Ready for Review